### PR TITLE
Add companies admin pages

### DIFF
--- a/src/app/[language]/admin-panel/companies/create/page-content.tsx
+++ b/src/app/[language]/admin-panel/companies/create/page-content.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import Button from "@mui/material/Button";
+import { useForm, FormProvider, useFormState } from "react-hook-form";
+import Container from "@mui/material/Container";
+import Grid from "@mui/material/Grid";
+import Typography from "@mui/material/Typography";
+import * as yup from "yup";
+import { yupResolver } from "@hookform/resolvers/yup";
+import withPageRequiredAuth from "@/services/auth/with-page-required-auth";
+import { useSnackbar } from "@/hooks/use-snackbar";
+import Link from "@/components/link";
+import Box from "@mui/material/Box";
+import HTTP_CODES_ENUM from "@/services/api/types/http-codes";
+import { useTranslation } from "@/services/i18n/client";
+import { useRouter } from "next/navigation";
+import { usePostCompanyService } from "@/services/api/services/companies";
+import FormTextInput from "@/components/form/text-input/form-text-input";
+import { RoleEnum } from "@/services/api/types/role";
+
+type CreateFormData = {
+  name: string;
+  address?: string;
+};
+
+const defaultValues: CreateFormData = {
+  name: "",
+  address: "",
+};
+
+const useValidationSchema = () => {
+  const { t } = useTranslation("admin-panel-companies-create");
+
+  return yup.object().shape({
+    name: yup.string().required(t("inputs.name.validation.required")),
+    address: yup.string().optional(),
+  });
+};
+
+function CreateFormActions() {
+  const { t } = useTranslation("admin-panel-companies-create");
+  const { isSubmitting, isDirty } = useFormState();
+
+  return (
+    <Button
+      variant="contained"
+      color="primary"
+      type="submit"
+      disabled={isSubmitting}
+      data-testid="submit-button"
+    >
+      {t("actions.submit")}
+    </Button>
+  );
+}
+
+function FormCreate() {
+  const router = useRouter();
+  const fetchCreateCompany = usePostCompanyService();
+  const { t } = useTranslation("admin-panel-companies-create");
+  const validationSchema = useValidationSchema();
+
+  const { enqueueSnackbar } = useSnackbar();
+
+  const methods = useForm<CreateFormData>({
+    resolver: yupResolver(validationSchema),
+    defaultValues,
+  });
+
+  const { handleSubmit, setError } = methods;
+
+  const onSubmit = handleSubmit(async (formData) => {
+    const { data, status } = await fetchCreateCompany(formData);
+
+    if (status === HTTP_CODES_ENUM.UNPROCESSABLE_ENTITY) {
+      (Object.keys(data.errors) as Array<keyof CreateFormData>).forEach((key) => {
+        setError(key, {
+          type: "manual",
+          message: t(`inputs.${key}.validation.server.${data.errors[key]}`),
+        });
+      });
+
+      return;
+    }
+
+    if (status === HTTP_CODES_ENUM.CREATED) {
+      enqueueSnackbar(t("alerts.success"), {
+        variant: "success",
+      });
+      router.push("/admin-panel/companies");
+    }
+  });
+
+  return (
+    <FormProvider {...methods}>
+      <Container maxWidth="md">
+        <form onSubmit={onSubmit}>
+          <Grid container spacing={2} mb={3} mt={3}>
+            <Grid item xs={12}>
+              <Typography variant="h6">{t("title")}</Typography>
+            </Grid>
+
+            <Grid item xs={12}>
+              <FormTextInput<CreateFormData>
+                name="name"
+                label={t("inputs.name.label")}
+              />
+            </Grid>
+
+            <Grid item xs={12}>
+              <FormTextInput<CreateFormData>
+                name="address"
+                label={t("inputs.address.label")}
+              />
+            </Grid>
+
+            <Grid item xs={12}>
+              <CreateFormActions />
+              <Box ml={1} component="span">
+                <Button
+                  variant="contained"
+                  color="inherit"
+                  LinkComponent={Link}
+                  href="/admin-panel/companies"
+                >
+                  {t("actions.cancel")}
+                </Button>
+              </Box>
+            </Grid>
+          </Grid>
+        </form>
+      </Container>
+    </FormProvider>
+  );
+}
+
+function CreateCompany() {
+  return <FormCreate />;
+}
+
+export default withPageRequiredAuth(CreateCompany, { roles: [RoleEnum.ADMIN] });

--- a/src/app/[language]/admin-panel/companies/create/page.tsx
+++ b/src/app/[language]/admin-panel/companies/create/page.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from "next";
+import CreateCompany from "./page-content";
+import { getServerTranslation } from "@/services/i18n";
+
+type Props = {
+  params: Promise<{ language: string }>;
+};
+
+export async function generateMetadata(props: Props): Promise<Metadata> {
+  const params = await props.params;
+
+  const { t } = await getServerTranslation(
+    params.language,
+    "admin-panel-companies-create"
+  );
+
+  return {
+    title: t("title"),
+  };
+}
+
+export default function Page() {
+  return <CreateCompany />;
+}

--- a/src/app/[language]/admin-panel/companies/edit/[id]/page-content.tsx
+++ b/src/app/[language]/admin-panel/companies/edit/[id]/page-content.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import Button from "@mui/material/Button";
+import { useForm, FormProvider, useFormState } from "react-hook-form";
+import Container from "@mui/material/Container";
+import Grid from "@mui/material/Grid";
+import Typography from "@mui/material/Typography";
+import * as yup from "yup";
+import { yupResolver } from "@hookform/resolvers/yup";
+import withPageRequiredAuth from "@/services/auth/with-page-required-auth";
+import { useEffect } from "react";
+import { useSnackbar } from "@/hooks/use-snackbar";
+import Link from "@/components/link";
+import Box from "@mui/material/Box";
+import HTTP_CODES_ENUM from "@/services/api/types/http-codes";
+import { useTranslation } from "@/services/i18n/client";
+import {
+  useGetCompanyService,
+  usePatchCompanyService,
+} from "@/services/api/services/companies";
+import { useParams } from "next/navigation";
+import FormTextInput from "@/components/form/text-input/form-text-input";
+import { RoleEnum } from "@/services/api/types/role";
+
+type EditFormData = {
+  name: string;
+  address?: string;
+};
+
+const useValidationSchema = () => {
+  const { t } = useTranslation("admin-panel-companies-edit");
+
+  return yup.object().shape({
+    name: yup.string().required(t("inputs.name.validation.required")),
+    address: yup.string().optional(),
+  });
+};
+
+function EditFormActions() {
+  const { t } = useTranslation("admin-panel-companies-edit");
+  const { isSubmitting, isDirty } = useFormState();
+
+  return (
+    <Button variant="contained" color="primary" type="submit" disabled={isSubmitting}>
+      {t("actions.submit")}
+    </Button>
+  );
+}
+
+function FormEditCompany() {
+  const params = useParams<{ id: string }>();
+  const companyId = params.id;
+  const fetchGetCompany = useGetCompanyService();
+  const fetchPatchCompany = usePatchCompanyService();
+  const { t } = useTranslation("admin-panel-companies-edit");
+  const validationSchema = useValidationSchema();
+  const { enqueueSnackbar } = useSnackbar();
+
+  const methods = useForm<EditFormData>({
+    resolver: yupResolver(validationSchema),
+    defaultValues: {
+      name: "",
+      address: "",
+    },
+  });
+
+  const { handleSubmit, setError, reset } = methods;
+
+  const onSubmit = handleSubmit(async (formData) => {
+    const { data, status } = await fetchPatchCompany({
+      id: companyId,
+      data: formData,
+    });
+    if (status === HTTP_CODES_ENUM.UNPROCESSABLE_ENTITY) {
+      (Object.keys(data.errors) as Array<keyof EditFormData>).forEach((key) => {
+        setError(key, {
+          type: "manual",
+          message: t(`inputs.${key}.validation.server.${data.errors[key]}`),
+        });
+      });
+      return;
+    }
+    if (status === HTTP_CODES_ENUM.OK) {
+      reset(formData);
+      enqueueSnackbar(t("alerts.success"), {
+        variant: "success",
+      });
+    }
+  });
+
+  useEffect(() => {
+    const getInitialData = async () => {
+      const { status, data } = await fetchGetCompany({ id: companyId });
+
+      if (status === HTTP_CODES_ENUM.OK) {
+        reset({
+          name: data?.name ?? "",
+          address: data?.address ?? "",
+        });
+      }
+    };
+
+    getInitialData();
+  }, [companyId, reset, fetchGetCompany]);
+
+  return (
+    <FormProvider {...methods}>
+      <Container maxWidth="md">
+        <form onSubmit={onSubmit}>
+          <Grid container spacing={2} mb={3} mt={3}>
+            <Grid item xs={12}>
+              <Typography variant="h6">{t("title")}</Typography>
+            </Grid>
+
+            <Grid item xs={12}>
+              <FormTextInput<EditFormData>
+                name="name"
+                label={t("inputs.name.label")}
+              />
+            </Grid>
+
+            <Grid item xs={12}>
+              <FormTextInput<EditFormData>
+                name="address"
+                label={t("inputs.address.label")}
+              />
+            </Grid>
+
+            <Grid item xs={12}>
+              <EditFormActions />
+              <Box ml={1} component="span">
+                <Button
+                  variant="contained"
+                  color="inherit"
+                  LinkComponent={Link}
+                  href="/admin-panel/companies"
+                >
+                  {t("actions.cancel")}
+                </Button>
+              </Box>
+            </Grid>
+          </Grid>
+        </form>
+      </Container>
+    </FormProvider>
+  );
+}
+
+function EditCompany() {
+  return <FormEditCompany />;
+}
+
+export default withPageRequiredAuth(EditCompany, { roles: [RoleEnum.ADMIN] });

--- a/src/app/[language]/admin-panel/companies/edit/[id]/page.tsx
+++ b/src/app/[language]/admin-panel/companies/edit/[id]/page.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from "next";
+import EditCompany from "./page-content";
+import { getServerTranslation } from "@/services/i18n";
+
+type Props = {
+  params: Promise<{ language: string }>;
+};
+
+export async function generateMetadata(props: Props): Promise<Metadata> {
+  const params = await props.params;
+
+  const { t } = await getServerTranslation(
+    params.language,
+    "admin-panel-companies-edit"
+  );
+
+  return {
+    title: t("title"),
+  };
+}
+
+export default function Page() {
+  return <EditCompany />;
+}

--- a/src/app/[language]/admin-panel/companies/page-content.tsx
+++ b/src/app/[language]/admin-panel/companies/page-content.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import withPageRequiredAuth from "@/services/auth/with-page-required-auth";
+import { RoleEnum } from "@/services/api/types/role";
+import { useTranslation } from "@/services/i18n/client";
+import Container from "@mui/material/Container";
+import Grid from "@mui/material/Grid";
+import Typography from "@mui/material/Typography";
+import Button from "@mui/material/Button";
+import Link from "@/components/link";
+import { TableVirtuoso } from "react-virtuoso";
+import TableCell from "@mui/material/TableCell";
+import TableRow from "@mui/material/TableRow";
+import TableComponents from "@/components/table/table-components";
+import { useGetCompaniesQuery, companiesQueryKeys } from "./queries/queries";
+import LinearProgress from "@mui/material/LinearProgress";
+import { useDeleteCompaniesService } from "@/services/api/services/companies";
+import useConfirmDialog from "@/components/confirm-dialog/use-confirm-dialog";
+import { InfiniteData, useQueryClient } from "@tanstack/react-query";
+
+function PageContent() {
+  const { t } = useTranslation("admin-panel-companies");
+  const query = useGetCompaniesQuery();
+  const deleteCompany = useDeleteCompaniesService();
+  const { confirmDialog } = useConfirmDialog();
+  const queryClient = useQueryClient();
+
+  const handleDelete = async (id: string) => {
+    const isConfirmed = await confirmDialog({
+      title: t("confirm.delete.title"),
+      message: t("confirm.delete.message"),
+    });
+
+    if (isConfirmed) {
+      const previousData = queryClient.getQueryData<
+        InfiniteData<{ nextPage: number; data: any[] }>
+      >(companiesQueryKeys.list().key);
+
+      await queryClient.cancelQueries({ queryKey: companiesQueryKeys.list().key });
+
+      const newData = {
+        ...previousData,
+        pages: previousData?.pages.map((page) => ({
+          ...page,
+          data: page?.data.filter((item) => item.id !== id),
+        })),
+      };
+
+      queryClient.setQueryData(companiesQueryKeys.list().key, newData);
+
+      await deleteCompany({ id });
+    }
+  };
+
+  return (
+    <Container maxWidth="md">
+      <Grid container spacing={3} wrap="nowrap" pt={3}>
+        <Grid item xs={12}>
+          <Typography variant="h3" gutterBottom>
+            {t("title")}
+          </Typography>
+          <Button
+            variant="contained"
+            color="primary"
+            LinkComponent={Link}
+            href="/admin-panel/companies/create"
+          >
+            {t("actions.create")}
+          </Button>
+        </Grid>
+        <Grid item xs={12}>
+          <TableVirtuoso
+            data={query.data?.pages.flatMap((page) => page.data) || []}
+            components={TableComponents({ loading: query.isLoading })}
+            endReached={query.fetchNextPage}
+            itemContent={(index, company) => (
+              <>
+                <TableCell>{company.id}</TableCell>
+                <TableCell>{company.name}</TableCell>
+                <TableCell>
+                  <Button
+                    size="small"
+                    color="primary"
+                    variant="contained"
+                    LinkComponent={Link}
+                    href={`/admin-panel/companies/edit/${company.id}`}
+                  >
+                    {t("actions.edit")}
+                  </Button>
+                  <Button
+                    size="small"
+                    color="inherit"
+                    variant="contained"
+                    onClick={() => handleDelete(company.id)}
+                    style={{ marginLeft: 8 }}
+                  >
+                    {t("actions.delete")}
+                  </Button>
+                </TableCell>
+              </>
+            )}
+            fixedHeaderContent={() => (
+              <TableRow>
+                <TableCell>ID</TableCell>
+                <TableCell>{t("table.column2")}</TableCell>
+                <TableCell>{t("table.column3")}</TableCell>
+              </TableRow>
+            )}
+          />
+          {query.isFetching && <LinearProgress />}
+        </Grid>
+      </Grid>
+    </Container>
+  );
+}
+
+export default withPageRequiredAuth(PageContent, { roles: [RoleEnum.ADMIN] });

--- a/src/app/[language]/admin-panel/companies/page.tsx
+++ b/src/app/[language]/admin-panel/companies/page.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from "next";
+import CompaniesPage from "./page-content";
+import { getServerTranslation } from "@/services/i18n";
+
+type Props = {
+  params: Promise<{ language: string }>;
+};
+
+export async function generateMetadata(props: Props): Promise<Metadata> {
+  const params = await props.params;
+
+  const { t } = await getServerTranslation(
+    params.language,
+    "admin-panel-companies"
+  );
+
+  return {
+    title: t("title"),
+  };
+}
+
+export default function Page() {
+  return <CompaniesPage />;
+}

--- a/src/app/[language]/admin-panel/companies/queries/queries.ts
+++ b/src/app/[language]/admin-panel/companies/queries/queries.ts
@@ -1,0 +1,41 @@
+import { useGetCompaniesService } from "@/services/api/services/companies";
+import HTTP_CODES_ENUM from "@/services/api/types/http-codes";
+import { createQueryKeys } from "@/services/react-query/query-key-factory";
+import { useInfiniteQuery } from "@tanstack/react-query";
+
+export const companiesQueryKeys = createQueryKeys(["companies"], {
+  list: () => ({
+    key: [],
+  }),
+});
+
+export const useGetCompaniesQuery = () => {
+  const fetch = useGetCompaniesService();
+
+  const query = useInfiniteQuery({
+    queryKey: companiesQueryKeys.list().key,
+    initialPageParam: 1,
+    queryFn: async ({ pageParam, signal }) => {
+      const { status, data } = await fetch(
+        {
+          page: pageParam,
+          limit: 10,
+        },
+        { signal }
+      );
+
+      if (status === HTTP_CODES_ENUM.OK) {
+        return {
+          data: data.data,
+          nextPage: data.hasNextPage ? pageParam + 1 : undefined,
+        };
+      }
+    },
+    getNextPageParam: (lastPage) => {
+      return lastPage?.nextPage;
+    },
+    gcTime: 0,
+  });
+
+  return query;
+};

--- a/src/services/api/services/companies.ts
+++ b/src/services/api/services/companies.ts
@@ -1,0 +1,113 @@
+import { useCallback } from "react";
+import useFetch from "../use-fetch";
+import { API_URL } from "../config";
+import wrapperFetchJsonResponse from "../wrapper-fetch-json-response";
+import { Company } from "../types/company";
+import { InfinityPaginationType } from "../types/infinity-pagination";
+import { RequestConfigType } from "./types/request-config";
+
+export type CompaniesRequest = {
+  page: number;
+  limit: number;
+};
+
+export type CompaniesResponse = InfinityPaginationType<Company>;
+
+export function useGetCompaniesService() {
+  const fetch = useFetch();
+
+  return useCallback(
+    (data: CompaniesRequest, requestConfig?: RequestConfigType) => {
+      const requestUrl = new URL(`${API_URL}/v1/companies`);
+      requestUrl.searchParams.append("page", data.page.toString());
+      requestUrl.searchParams.append("limit", data.limit.toString());
+
+      return fetch(requestUrl, {
+        method: "GET",
+        ...requestConfig,
+      }).then(wrapperFetchJsonResponse<CompaniesResponse>);
+    },
+    [fetch]
+  );
+}
+
+export type CompanyRequest = {
+  id: Company["id"];
+};
+
+export type CompanyResponse = Company;
+
+export function useGetCompanyService() {
+  const fetch = useFetch();
+
+  return useCallback(
+    (data: CompanyRequest, requestConfig?: RequestConfigType) => {
+      return fetch(`${API_URL}/v1/companies/${data.id}`, {
+        method: "GET",
+        ...requestConfig,
+      }).then(wrapperFetchJsonResponse<CompanyResponse>);
+    },
+    [fetch]
+  );
+}
+
+export type CompanyPostRequest = Omit<Company, "id">;
+
+export type CompanyPostResponse = Company;
+
+export function usePostCompanyService() {
+  const fetch = useFetch();
+
+  return useCallback(
+    (data: CompanyPostRequest, requestConfig?: RequestConfigType) => {
+      return fetch(`${API_URL}/v1/companies`, {
+        method: "POST",
+        body: JSON.stringify(data),
+        ...requestConfig,
+      }).then(wrapperFetchJsonResponse<CompanyPostResponse>);
+    },
+    [fetch]
+  );
+}
+
+export type CompanyPatchRequest = {
+  id: Company["id"];
+  data: Partial<Omit<Company, "id">>;
+};
+
+export type CompanyPatchResponse = Company;
+
+export function usePatchCompanyService() {
+  const fetch = useFetch();
+
+  return useCallback(
+    (data: CompanyPatchRequest, requestConfig?: RequestConfigType) => {
+      return fetch(`${API_URL}/v1/companies/${data.id}`, {
+        method: "PATCH",
+        body: JSON.stringify(data.data),
+        ...requestConfig,
+      }).then(wrapperFetchJsonResponse<CompanyPatchResponse>);
+    },
+    [fetch]
+  );
+}
+
+export type CompaniesDeleteRequest = {
+  id: Company["id"];
+};
+
+export type CompaniesDeleteResponse = undefined;
+
+export function useDeleteCompaniesService() {
+  const fetch = useFetch();
+
+  return useCallback(
+    (data: CompaniesDeleteRequest, requestConfig?: RequestConfigType) => {
+      return fetch(`${API_URL}/v1/companies/${data.id}`, {
+        method: "DELETE",
+        ...requestConfig,
+      }).then(wrapperFetchJsonResponse<CompaniesDeleteResponse>);
+    },
+    [fetch]
+  );
+}

--- a/src/services/api/types/company.ts
+++ b/src/services/api/types/company.ts
@@ -1,0 +1,5 @@
+export type Company = {
+  id: string;
+  name: string;
+  address?: string;
+};

--- a/src/services/i18n/locales/en/admin-panel-companies-create.json
+++ b/src/services/i18n/locales/en/admin-panel-companies-create.json
@@ -1,0 +1,26 @@
+{
+  "title": "Create company",
+  "actions": {
+    "submit": "Save",
+    "cancel": "Cancel"
+  },
+  "inputs": {
+    "name": {
+      "label": "Name",
+      "validation": {
+        "required": "Name is required",
+        "server": {}
+      }
+    },
+    "address": {
+      "label": "Address",
+      "validation": {
+        "server": {}
+      }
+    },
+    "<system>": "Do not remove this property"
+  },
+  "alerts": {
+    "success": "Company has been created successfully"
+  }
+}

--- a/src/services/i18n/locales/en/admin-panel-companies-edit.json
+++ b/src/services/i18n/locales/en/admin-panel-companies-edit.json
@@ -1,0 +1,26 @@
+{
+  "title": "Edit company",
+  "actions": {
+    "submit": "Save",
+    "cancel": "Cancel"
+  },
+  "inputs": {
+    "name": {
+      "label": "Name",
+      "validation": {
+        "required": "Name is required",
+        "server": {}
+      }
+    },
+    "address": {
+      "label": "Address",
+      "validation": {
+        "server": {}
+      }
+    },
+    "<system>": "Do not remove this property"
+  },
+  "alerts": {
+    "success": "Company has been updated successfully"
+  }
+}

--- a/src/services/i18n/locales/en/admin-panel-companies.json
+++ b/src/services/i18n/locales/en/admin-panel-companies.json
@@ -1,0 +1,18 @@
+{
+  "title": "Companies",
+  "table": {
+    "column2": "Name",
+    "column3": "Actions"
+  },
+  "actions": {
+    "create": "Create Company",
+    "edit": "Edit",
+    "delete": "Delete"
+  },
+  "confirm": {
+    "delete": {
+      "title": "Delete Company",
+      "message": "Are you sure you want to delete this company?"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- implement API service for companies CRUD
- add React pages for listing, creating, and editing companies
- include React Query hooks for fetching companies
- provide i18n resources for new pages

## Testing
- `npm run lint` *(fails: next not found)*