### PR TITLE
Add basic opportunities CRUD

### DIFF
--- a/src/app/[language]/opportunities/[id]/edit/page-content.tsx
+++ b/src/app/[language]/opportunities/[id]/edit/page-content.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Container from "@mui/material/Container";
+import withPageRequiredAuth from "@/services/auth/with-page-required-auth";
+import { RoleEnum } from "@/services/api/types/role";
+import OpportunityForm, { OpportunityFormData } from "@/components/opportunity/opportunity-form";
+import { useGetOpportunityService } from "@/services/api/services/opportunities";
+import { useParams, useRouter } from "next/navigation";
+import HTTP_CODES_ENUM from "@/services/api/types/http-codes";
+
+function PageContent() {
+  const params = useParams<{ id: string }>();
+  const router = useRouter();
+  const fetchOpportunity = useGetOpportunityService();
+  const [initialValues, setInitialValues] = useState<OpportunityFormData & { id: number }>();
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      const { status, data } = await fetchOpportunity({ id: Number(params.id) });
+      if (status === HTTP_CODES_ENUM.OK) {
+        const mapped = {
+          id: data.id,
+          type: data.type,
+          clients: data.clients,
+          partners: data.partners,
+        };
+        setInitialValues(mapped);
+      }
+      setLoading(false);
+    };
+    load();
+  }, [fetchOpportunity, params.id]);
+
+  if (loading) return <p>Loading...</p>;
+  if (!initialValues) return null;
+
+  return (
+    <Container maxWidth="md" sx={{ mt: 4 }}>
+      <OpportunityForm
+        initialValues={initialValues}
+        onSuccess={() => router.push("/opportunities")}
+      />
+    </Container>
+  );
+}
+
+export default withPageRequiredAuth(PageContent, { roles: [RoleEnum.ADMIN] });

--- a/src/app/[language]/opportunities/[id]/edit/page.tsx
+++ b/src/app/[language]/opportunities/[id]/edit/page.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from "next";
+import { getServerTranslation } from "@/services/i18n";
+import PageContent from "./page-content";
+
+type Props = {
+  params: Promise<{ language: string }>;
+};
+
+export async function generateMetadata(props: Props): Promise<Metadata> {
+  const params = await props.params;
+  const { t } = await getServerTranslation(params.language, "opportunities");
+  return { title: t("edit") };
+}
+
+export default function Page() {
+  return <PageContent />;
+}

--- a/src/app/[language]/opportunities/create/page-content.tsx
+++ b/src/app/[language]/opportunities/create/page-content.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import Container from "@mui/material/Container";
+import withPageRequiredAuth from "@/services/auth/with-page-required-auth";
+import { RoleEnum } from "@/services/api/types/role";
+import OpportunityForm from "@/components/opportunity/opportunity-form";
+import { useRouter } from "next/navigation";
+
+function PageContent() {
+  const router = useRouter();
+  return (
+    <Container maxWidth="md" sx={{ mt: 4 }}>
+      <OpportunityForm onSuccess={() => router.push("/opportunities")}/>
+    </Container>
+  );
+}
+
+export default withPageRequiredAuth(PageContent, { roles: [RoleEnum.ADMIN] });

--- a/src/app/[language]/opportunities/create/page.tsx
+++ b/src/app/[language]/opportunities/create/page.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from "next";
+import { getServerTranslation } from "@/services/i18n";
+import PageContent from "./page-content";
+
+type Props = {
+  params: Promise<{ language: string }>;
+};
+
+export async function generateMetadata(props: Props): Promise<Metadata> {
+  const params = await props.params;
+  const { t } = await getServerTranslation(params.language, "opportunities");
+  return { title: t("create") };
+}
+
+export default function Page() {
+  return <PageContent />;
+}

--- a/src/app/[language]/opportunities/list/page-content.tsx
+++ b/src/app/[language]/opportunities/list/page-content.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import withPageRequiredAuth from "@/services/auth/with-page-required-auth";
+import { RoleEnum } from "@/services/api/types/role";
+import Container from "@mui/material/Container";
+import OpportunitiesList from "@/components/opportunity/opportunities-list";
+
+function PageContent() {
+  return (
+    <Container maxWidth="md" sx={{ mt: 4 }}>
+      <OpportunitiesList />
+    </Container>
+  );
+}
+
+export default withPageRequiredAuth(PageContent, { roles: [RoleEnum.ADMIN] });

--- a/src/app/[language]/opportunities/list/page.tsx
+++ b/src/app/[language]/opportunities/list/page.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from "next";
+import { getServerTranslation } from "@/services/i18n";
+import PageContent from "./page-content";
+
+type Props = {
+  params: Promise<{ language: string }>;
+};
+
+export async function generateMetadata(props: Props): Promise<Metadata> {
+  const params = await props.params;
+  const { t } = await getServerTranslation(params.language, "opportunities");
+
+  return { title: t("title") };
+}
+
+export default function Page() {
+  return <PageContent />;
+}

--- a/src/app/[language]/opportunities/page.tsx
+++ b/src/app/[language]/opportunities/page.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from "next";
+import { getServerTranslation } from "@/services/i18n";
+import PageContent from "./list/page-content";
+
+type Props = {
+  params: Promise<{ language: string }>;
+};
+
+export async function generateMetadata(props: Props): Promise<Metadata> {
+  const params = await props.params;
+  const { t } = await getServerTranslation(params.language, "opportunities");
+  return { title: t("title") };
+}
+
+export default function Page() {
+  return <PageContent />;
+}

--- a/src/components/opportunity/opportunities-list.tsx
+++ b/src/components/opportunity/opportunities-list.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+import Button from "@mui/material/Button";
+import Link from "next/link";
+import IconButton from "@mui/material/IconButton";
+import DeleteIcon from "@mui/icons-material/Delete";
+import EditIcon from "@mui/icons-material/Edit";
+import { useRouter } from "next/navigation";
+import {
+  useDeleteOpportunityService,
+  useGetOpportunitiesService,
+} from "@/services/api/services/opportunities";
+import HTTP_CODES_ENUM from "@/services/api/types/http-codes";
+import { Opportunity } from "@/services/api/types/opportunity";
+import { useSnackbar } from "@/hooks/use-snackbar";
+
+function OpportunitiesList() {
+  const router = useRouter();
+  const fetchOpportunities = useGetOpportunitiesService();
+  const deleteOpportunity = useDeleteOpportunityService();
+  const { enqueueSnackbar } = useSnackbar();
+
+  const [data, setData] = useState<Opportunity[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const load = async () => {
+    setLoading(true);
+    const { status, data } = await fetchOpportunities({ page: 1, limit: 50 });
+    if (status === HTTP_CODES_ENUM.OK) {
+      setData(data.data as Opportunity[]);
+    }
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    load();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleDelete = async (id: number) => {
+    const { status } = await deleteOpportunity({ id });
+    if (status === HTTP_CODES_ENUM.OK || status === HTTP_CODES_ENUM.NO_CONTENT) {
+      enqueueSnackbar("Deleted", { variant: "success" });
+      load();
+    } else {
+      enqueueSnackbar("Error", { variant: "error" });
+    }
+  };
+
+  return (
+    <>
+      <Button
+        variant="contained"
+        onClick={() => router.push("/opportunities/create")}
+        sx={{ mb: 2 }}
+      >
+        Create Opportunity
+      </Button>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell>Type</TableCell>
+            <TableCell>Clients</TableCell>
+            <TableCell>Partners</TableCell>
+            <TableCell>Created At</TableCell>
+            <TableCell>Actions</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {data.map((op) => (
+            <TableRow key={op.id} hover>
+              <TableCell>{op.type}</TableCell>
+              <TableCell>{op.clients.length} clients</TableCell>
+              <TableCell>{op.partners.length} partners</TableCell>
+              <TableCell>{op.createdAt?.slice(0, 10)}</TableCell>
+              <TableCell>
+                <IconButton
+                  size="small"
+                  onClick={() => router.push(`/opportunities/${op.id}/edit`)}
+                >
+                  <EditIcon />
+                </IconButton>
+                <IconButton size="small" onClick={() => handleDelete(op.id)}>
+                  <DeleteIcon />
+                </IconButton>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+      {loading && <p>Loading...</p>}
+    </>
+  );
+}
+
+export default OpportunitiesList;

--- a/src/components/opportunity/opportunity-form.tsx
+++ b/src/components/opportunity/opportunity-form.tsx
@@ -1,0 +1,293 @@
+"use client";
+
+import Button from "@mui/material/Button";
+import Grid from "@mui/material/Grid";
+import Drawer from "@mui/material/Drawer";
+import { yupResolver } from "@hookform/resolvers/yup";
+import * as yup from "yup";
+import { InferType } from "yup";
+import {
+  FormProvider,
+  useFieldArray,
+  useForm,
+  useFormState,
+} from "react-hook-form";
+import { useEffect, useState } from "react";
+import FormSelectInput from "@/components/form/select/form-select";
+import { useGetCompaniesService } from "@/services/api/services/companies";
+import { useGetUsersService } from "@/services/api/services/users";
+import {
+  usePostOpportunityService,
+  usePutOpportunityService,
+} from "@/services/api/services/opportunities";
+import { useSnackbar } from "@/hooks/use-snackbar";
+import HTTP_CODES_ENUM from "@/services/api/types/http-codes";
+import { useRouter } from "next/navigation";
+
+export const validationSchema = yup.object({
+  type: yup
+    .string()
+    .oneOf(["factoring", "reverse_factoring", "credit_insurance"])
+    .required(),
+  clients: yup
+    .array()
+    .of(
+      yup.object({
+        company: yup
+          .object({ id: yup.number().required(), name: yup.string().nullable() })
+          .required(),
+        contacts: yup
+          .array()
+          .of(
+            yup.object({
+              id: yup.number().required(),
+              name: yup.string().nullable(),
+            })
+          )
+          .min(1)
+          .required(),
+      })
+    )
+    .min(1)
+    .required(),
+  partners: yup
+    .array()
+    .of(
+      yup.object({
+        type: yup.string().oneOf(["factor", "credit_insurer"]).required(),
+        company: yup
+          .object({ id: yup.number().required(), name: yup.string().nullable() })
+          .required(),
+        contacts: yup
+          .array()
+          .of(
+            yup.object({
+              id: yup.number().required(),
+              name: yup.string().nullable(),
+            })
+          )
+          .min(1)
+          .required(),
+      })
+    )
+    .min(1)
+    .required(),
+});
+
+export type OpportunityFormData = InferType<typeof validationSchema>;
+
+const emptyClient = {
+  company: { id: 0, name: "" },
+  contacts: [{ id: 0, name: "" }],
+};
+
+const emptyPartner = {
+  type: "factor" as const,
+  company: { id: 0, name: "" },
+  contacts: [{ id: 0, name: "" }],
+};
+
+type Props = {
+  initialValues?: OpportunityFormData & { id?: number };
+  onSuccess: () => void;
+};
+
+function OpportunityForm({ initialValues, onSuccess }: Props) {
+  const router = useRouter();
+  const { enqueueSnackbar } = useSnackbar();
+  const fetchCompanies = useGetCompaniesService();
+  const fetchUsers = useGetUsersService();
+  const postOpportunity = usePostOpportunityService();
+  const putOpportunity = usePutOpportunityService();
+
+  const [companies, setCompanies] = useState<{ id: number; name: string }[]>([]);
+  const [users, setUsers] = useState<{ id: number; name: string }[]>([]);
+  const [drawerOpen, setDrawerOpen] = useState(false); // placeholder
+
+  useEffect(() => {
+    const loadCompanies = async () => {
+      const { status, data } = await fetchCompanies({ page: 1, limit: 50 });
+      if (status === HTTP_CODES_ENUM.OK) {
+        setCompanies(data.data as { id: number; name: string }[]);
+      }
+    };
+    loadCompanies();
+  }, [fetchCompanies]);
+
+  useEffect(() => {
+    const loadUsers = async () => {
+      const { status, data } = await fetchUsers({ page: 1, limit: 50 });
+      if (status === HTTP_CODES_ENUM.OK) {
+        setUsers(data.data as { id: number; name: string }[]);
+      }
+    };
+    loadUsers();
+  }, [fetchUsers]);
+
+  const methods = useForm<OpportunityFormData>({
+    resolver: yupResolver(validationSchema),
+    defaultValues:
+      initialValues ?? {
+        type: undefined,
+        clients: [emptyClient],
+        partners: [emptyPartner],
+      },
+  });
+
+  const { control, handleSubmit, setError } = methods;
+  const { isSubmitting } = useFormState({ control });
+
+  const clientsArray = useFieldArray({ control, name: "clients" });
+  const partnersArray = useFieldArray({ control, name: "partners" });
+
+  const onSubmit = handleSubmit(async (formData) => {
+    const requestData = formData;
+    const { data, status } = initialValues?.id
+      ? await putOpportunity({ id: initialValues.id, data: requestData })
+      : await postOpportunity(requestData);
+    if (status === HTTP_CODES_ENUM.UNPROCESSABLE_ENTITY) {
+      (Object.keys(data.errors) as Array<keyof OpportunityFormData>).forEach(
+        (key) => {
+          setError(key, { type: "manual", message: data.errors[key] });
+        }
+      );
+      return;
+    }
+    if (status === HTTP_CODES_ENUM.CREATED || status === HTTP_CODES_ENUM.OK) {
+      enqueueSnackbar("Saved", { variant: "success" });
+      onSuccess();
+    }
+  });
+
+  return (
+    <FormProvider {...methods}>
+      <form onSubmit={onSubmit}>
+        <Grid container spacing={2} mb={3} mt={3}>
+          <Grid xs={12} item>
+            <FormSelectInput<OpportunityFormData, { id: string }>
+              name="type"
+              label="Type"
+              options={[
+                { id: "factoring" },
+                { id: "reverse_factoring" },
+                { id: "credit_insurance" },
+              ]}
+              keyValue="id"
+              renderOption={(opt) => opt.id}
+            />
+          </Grid>
+          {clientsArray.fields.map((field, index) => (
+            <Grid key={field.id || index} container spacing={2} xs={12} item>
+              <Grid xs={12} sm={6} item>
+                <FormSelectInput<OpportunityFormData, { id: number; name: string }>
+                  name={`clients.${index}.company`}
+                  label="Company"
+                  options={companies}
+                  keyValue="id"
+                  renderOption={(c) => c.name}
+                />
+              </Grid>
+              <Grid xs={12} sm={6} item>
+                <FormSelectInput<OpportunityFormData, { id: number; name: string }>
+                  name={`clients.${index}.contacts.0` as never}
+                  label="Contact"
+                  options={users}
+                  keyValue="id"
+                  renderOption={(u) => u.name}
+                />
+              </Grid>
+              <Grid xs={12} item>
+                <Button
+                  variant="contained"
+                  color="inherit"
+                  onClick={() => clientsArray.remove(index)}
+                >
+                  Remove Client
+                </Button>
+              </Grid>
+            </Grid>
+          ))}
+          <Grid xs={12} item>
+            <Button
+              variant="contained"
+              onClick={() => clientsArray.append(emptyClient)}
+            >
+              Add Client
+            </Button>
+          </Grid>
+          {partnersArray.fields.map((field, index) => (
+            <Grid key={field.id || index} container spacing={2} xs={12} item>
+              <Grid xs={12} sm={4} item>
+                <FormSelectInput<OpportunityFormData, { id: string }>
+                  name={`partners.${index}.type`}
+                  label="Partner Type"
+                  options={[{ id: "factor" }, { id: "credit_insurer" }]}
+                  keyValue="id"
+                  renderOption={(o) => o.id}
+                />
+              </Grid>
+              <Grid xs={12} sm={4} item>
+                <FormSelectInput<OpportunityFormData, { id: number; name: string }>
+                  name={`partners.${index}.company`}
+                  label="Company"
+                  options={companies}
+                  keyValue="id"
+                  renderOption={(c) => c.name}
+                />
+              </Grid>
+              <Grid xs={12} sm={4} item>
+                <FormSelectInput<OpportunityFormData, { id: number; name: string }>
+                  name={`partners.${index}.contacts.0` as never}
+                  label="Contact"
+                  options={users}
+                  keyValue="id"
+                  renderOption={(u) => u.name}
+                />
+              </Grid>
+              <Grid xs={12} item>
+                <Button
+                  variant="contained"
+                  color="inherit"
+                  onClick={() => partnersArray.remove(index)}
+                >
+                  Remove Partner
+                </Button>
+              </Grid>
+            </Grid>
+          ))}
+          <Grid xs={12} item>
+            <Button
+              variant="contained"
+              onClick={() => partnersArray.append(emptyPartner)}
+            >
+              Add Partner
+            </Button>
+          </Grid>
+          <Grid xs={12} item>
+            <Button type="submit" variant="contained" disabled={isSubmitting}>
+              Submit
+            </Button>
+            <Button
+              sx={{ ml: 1 }}
+              variant="contained"
+              color="inherit"
+              onClick={() => router.push("/opportunities")}
+            >
+              Cancel
+            </Button>
+          </Grid>
+        </Grid>
+      </form>
+      <Drawer
+        anchor="right"
+        open={drawerOpen}
+        onClose={() => setDrawerOpen(false)}
+        PaperProps={{ sx: { width: "50vw" } }}
+      >
+        {/* TODO: create company or user forms */}
+      </Drawer>
+    </FormProvider>
+  );
+}
+
+export default OpportunityForm;

--- a/src/services/api/services/opportunities.ts
+++ b/src/services/api/services/opportunities.ts
@@ -1,0 +1,101 @@
+import { useCallback } from "react";
+import useFetch from "../use-fetch";
+import { API_URL } from "../config";
+import wrapperFetchJsonResponse from "../wrapper-fetch-json-response";
+import { Opportunity } from "../types/opportunity";
+import { InfinityPaginationType } from "../types/infinity-pagination";
+import { RequestConfigType } from "./types/request-config";
+
+export type OpportunitiesRequest = { page: number; limit: number };
+export type OpportunitiesResponse = InfinityPaginationType<Opportunity>;
+
+export function useGetOpportunitiesService() {
+  const fetch = useFetch();
+
+  return useCallback(
+    (data: OpportunitiesRequest, requestConfig?: RequestConfigType) => {
+      const requestUrl = new URL(`${API_URL}/v1/opportunities`);
+      requestUrl.searchParams.append("page", data.page.toString());
+      requestUrl.searchParams.append("limit", data.limit.toString());
+
+      return fetch(requestUrl, {
+        method: "GET",
+        ...requestConfig,
+      }).then(wrapperFetchJsonResponse<OpportunitiesResponse>);
+    },
+    [fetch]
+  );
+}
+
+export type OpportunityRequest = { id: Opportunity["id"] };
+export type OpportunityResponse = Opportunity;
+
+export function useGetOpportunityService() {
+  const fetch = useFetch();
+
+  return useCallback(
+    (data: OpportunityRequest, requestConfig?: RequestConfigType) => {
+      return fetch(`${API_URL}/v1/opportunities/${data.id}`, {
+        method: "GET",
+        ...requestConfig,
+      }).then(wrapperFetchJsonResponse<OpportunityResponse>);
+    },
+    [fetch]
+  );
+}
+
+export type OpportunityPostRequest = Omit<Opportunity, "id" | "createdAt">;
+export type OpportunityPostResponse = Opportunity;
+
+export function usePostOpportunityService() {
+  const fetch = useFetch();
+
+  return useCallback(
+    (data: OpportunityPostRequest, requestConfig?: RequestConfigType) => {
+      return fetch(`${API_URL}/v1/opportunities`, {
+        method: "POST",
+        body: JSON.stringify(data),
+        ...requestConfig,
+      }).then(wrapperFetchJsonResponse<OpportunityPostResponse>);
+    },
+    [fetch]
+  );
+}
+
+export type OpportunityPutRequest = {
+  id: Opportunity["id"];
+  data: OpportunityPostRequest;
+};
+export type OpportunityPutResponse = Opportunity;
+
+export function usePutOpportunityService() {
+  const fetch = useFetch();
+
+  return useCallback(
+    (data: OpportunityPutRequest, requestConfig?: RequestConfigType) => {
+      return fetch(`${API_URL}/v1/opportunities/${data.id}`, {
+        method: "PUT",
+        body: JSON.stringify(data.data),
+        ...requestConfig,
+      }).then(wrapperFetchJsonResponse<OpportunityPutResponse>);
+    },
+    [fetch]
+  );
+}
+
+export type OpportunityDeleteRequest = { id: Opportunity["id"] };
+export type OpportunityDeleteResponse = undefined;
+
+export function useDeleteOpportunityService() {
+  const fetch = useFetch();
+
+  return useCallback(
+    (data: OpportunityDeleteRequest, requestConfig?: RequestConfigType) => {
+      return fetch(`${API_URL}/v1/opportunities/${data.id}`, {
+        method: "DELETE",
+        ...requestConfig,
+      }).then(wrapperFetchJsonResponse<OpportunityDeleteResponse>);
+    },
+    [fetch]
+  );
+}

--- a/src/services/api/types/opportunity.ts
+++ b/src/services/api/types/opportunity.ts
@@ -1,0 +1,18 @@
+export type OpportunityPartner = {
+  type: "factor" | "credit_insurer";
+  company: { id: number; name?: string | null };
+  contacts: { id: number; name?: string | null }[];
+};
+
+export type OpportunityClient = {
+  company: { id: number; name?: string | null };
+  contacts: { id: number; name?: string | null }[];
+};
+
+export type Opportunity = {
+  id: number;
+  type: "factoring" | "reverse_factoring" | "credit_insurance";
+  clients: OpportunityClient[];
+  partners: OpportunityPartner[];
+  createdAt: string;
+};


### PR DESCRIPTION
## Summary
- scaffold Opportunity API types and services
- create OpportunityForm with basic field arrays and submission logic
- add OpportunitiesList table view
- wire new pages for listing, creating and editing opportunities

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683dcba67d688322b7df826b993eccf7