### PR TITLE
Add opportunities mock data and menu

### DIFF
--- a/src/app/[language]/opportunities/[id]/edit/page-content.tsx
+++ b/src/app/[language]/opportunities/[id]/edit/page-content.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Container from "@mui/material/Container";
+import withPageRequiredAuth from "@/services/auth/with-page-required-auth";
+import { RoleEnum } from "@/services/api/types/role";
+import OpportunityForm, { OpportunityFormData } from "@/components/opportunity/opportunity-form";
+import { useGetOpportunityService } from "@/services/api/services/opportunities";
+import { useParams, useRouter } from "next/navigation";
+import HTTP_CODES_ENUM from "@/services/api/types/http-codes";
+
+function PageContent() {
+  const params = useParams<{ id: string }>();
+  const router = useRouter();
+  const fetchOpportunity = useGetOpportunityService();
+  const [initialValues, setInitialValues] = useState<OpportunityFormData & { id: number }>();
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      const { status, data } = await fetchOpportunity({ id: Number(params.id) });
+      if (status === HTTP_CODES_ENUM.OK) {
+        const mapped = {
+          id: data.id,
+          type: data.type,
+          clients: data.clients,
+          partners: data.partners,
+        };
+        setInitialValues(mapped);
+      }
+      setLoading(false);
+    };
+    load();
+  }, [fetchOpportunity, params.id]);
+
+  if (loading) return <p>Loading...</p>;
+  if (!initialValues) return null;
+
+  return (
+    <Container maxWidth="md" sx={{ mt: 4 }}>
+      <OpportunityForm
+        initialValues={initialValues}
+        onSuccess={() => router.push("/opportunities")}
+      />
+    </Container>
+  );
+}
+
+export default withPageRequiredAuth(PageContent, { roles: [RoleEnum.ADMIN] });

--- a/src/app/[language]/opportunities/[id]/edit/page.tsx
+++ b/src/app/[language]/opportunities/[id]/edit/page.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from "next";
+import { getServerTranslation } from "@/services/i18n";
+import PageContent from "./page-content";
+
+type Props = {
+  params: Promise<{ language: string }>;
+};
+
+export async function generateMetadata(props: Props): Promise<Metadata> {
+  const params = await props.params;
+  const { t } = await getServerTranslation(params.language, "opportunities");
+  return { title: t("edit") };
+}
+
+export default function Page() {
+  return <PageContent />;
+}

--- a/src/app/[language]/opportunities/create/page-content.tsx
+++ b/src/app/[language]/opportunities/create/page-content.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import Container from "@mui/material/Container";
+import withPageRequiredAuth from "@/services/auth/with-page-required-auth";
+import { RoleEnum } from "@/services/api/types/role";
+import OpportunityForm from "@/components/opportunity/opportunity-form";
+import { useRouter } from "next/navigation";
+
+function PageContent() {
+  const router = useRouter();
+  return (
+    <Container maxWidth="md" sx={{ mt: 4 }}>
+      <OpportunityForm onSuccess={() => router.push("/opportunities")}/>
+    </Container>
+  );
+}
+
+export default withPageRequiredAuth(PageContent, { roles: [RoleEnum.ADMIN] });

--- a/src/app/[language]/opportunities/create/page.tsx
+++ b/src/app/[language]/opportunities/create/page.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from "next";
+import { getServerTranslation } from "@/services/i18n";
+import PageContent from "./page-content";
+
+type Props = {
+  params: Promise<{ language: string }>;
+};
+
+export async function generateMetadata(props: Props): Promise<Metadata> {
+  const params = await props.params;
+  const { t } = await getServerTranslation(params.language, "opportunities");
+  return { title: t("create") };
+}
+
+export default function Page() {
+  return <PageContent />;
+}

--- a/src/app/[language]/opportunities/list/page-content.tsx
+++ b/src/app/[language]/opportunities/list/page-content.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import withPageRequiredAuth from "@/services/auth/with-page-required-auth";
+import { RoleEnum } from "@/services/api/types/role";
+import Container from "@mui/material/Container";
+import OpportunitiesList from "@/components/opportunity/opportunities-list";
+
+function PageContent() {
+  return (
+    <Container maxWidth="md" sx={{ mt: 4 }}>
+      <OpportunitiesList />
+    </Container>
+  );
+}
+
+export default withPageRequiredAuth(PageContent, { roles: [RoleEnum.ADMIN] });

--- a/src/app/[language]/opportunities/list/page.tsx
+++ b/src/app/[language]/opportunities/list/page.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from "next";
+import { getServerTranslation } from "@/services/i18n";
+import PageContent from "./page-content";
+
+type Props = {
+  params: Promise<{ language: string }>;
+};
+
+export async function generateMetadata(props: Props): Promise<Metadata> {
+  const params = await props.params;
+  const { t } = await getServerTranslation(params.language, "opportunities");
+
+  return { title: t("title") };
+}
+
+export default function Page() {
+  return <PageContent />;
+}

--- a/src/app/[language]/opportunities/page.tsx
+++ b/src/app/[language]/opportunities/page.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from "next";
+import { getServerTranslation } from "@/services/i18n";
+import PageContent from "./list/page-content";
+
+type Props = {
+  params: Promise<{ language: string }>;
+};
+
+export async function generateMetadata(props: Props): Promise<Metadata> {
+  const params = await props.params;
+  const { t } = await getServerTranslation(params.language, "opportunities");
+  return { title: t("title") };
+}
+
+export default function Page() {
+  return <PageContent />;
+}

--- a/src/components/app-bar.tsx
+++ b/src/components/app-bar.tsx
@@ -35,6 +35,8 @@ function ResponsiveAppBar() {
     useState<null | HTMLElement>(null);
   const [anchorElementCompanies, setAnchorElementCompanies] =
     useState<null | HTMLElement>(null);
+  const [anchorElementOpportunities, setAnchorElementOpportunities] =
+    useState<null | HTMLElement>(null);
 
   const handleOpenNavMenu = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorElementNav(event.currentTarget);
@@ -47,6 +49,9 @@ function ResponsiveAppBar() {
   };
   const handleOpenCompaniesMenu = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorElementCompanies(event.currentTarget);
+  };
+  const handleOpenOpportunitiesMenu = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorElementOpportunities(event.currentTarget);
   };
 
   const handleCloseNavMenu = () => {
@@ -61,6 +66,9 @@ function ResponsiveAppBar() {
   };
   const handleCloseCompaniesMenu = () => {
     setAnchorElementCompanies(null);
+  };
+  const handleCloseOpportunitiesMenu = () => {
+    setAnchorElementOpportunities(null);
   };
 
   return (
@@ -160,6 +168,26 @@ function ResponsiveAppBar() {
                   >
                     <Typography textAlign="center">
                       {t("common:navigation.usersCreate")}
+                    </Typography>
+                  </MenuItem>,
+                  <MenuItem
+                    key="opportunities"
+                    onClick={handleCloseNavMenu}
+                    component={Link}
+                    href="/opportunities"
+                  >
+                    <Typography textAlign="center">
+                      {t("common:navigation.opportunities")}
+                    </Typography>
+                  </MenuItem>,
+                  <MenuItem
+                    key="opportunities-create"
+                    onClick={handleCloseNavMenu}
+                    component={Link}
+                    href="/opportunities/create"
+                  >
+                    <Typography textAlign="center">
+                      {t("common:navigation.opportunitiesCreate")}
                     </Typography>
                   </MenuItem>,
                   // mobile-menu-items
@@ -293,13 +321,53 @@ function ResponsiveAppBar() {
                         {t("common:navigation.users")}
                       </Typography>
                     </MenuItem>
+                  <MenuItem
+                    onClick={handleCloseUsersMenu}
+                    component={Link}
+                    href="/admin-panel/users/create"
+                  >
+                    <Typography textAlign="center">
+                      {t("common:navigation.usersCreate")}
+                    </Typography>
+                  </MenuItem>
+                  </Menu>
+                  <Button
+                    onClick={handleOpenOpportunitiesMenu}
+                    sx={{ my: 2, color: "white", display: "block" }}
+                  >
+                    {t("common:navigation.opportunities")}
+                  </Button>
+                  <Menu
+                    id="menu-opportunities"
+                    anchorEl={anchorElementOpportunities}
+                    anchorOrigin={{
+                      vertical: "bottom",
+                      horizontal: "left",
+                    }}
+                    keepMounted
+                    transformOrigin={{
+                      vertical: "top",
+                      horizontal: "left",
+                    }}
+                    open={Boolean(anchorElementOpportunities)}
+                    onClose={handleCloseOpportunitiesMenu}
+                  >
                     <MenuItem
-                      onClick={handleCloseUsersMenu}
+                      onClick={handleCloseOpportunitiesMenu}
                       component={Link}
-                      href="/admin-panel/users/create"
+                      href="/opportunities"
                     >
                       <Typography textAlign="center">
-                        {t("common:navigation.usersCreate")}
+                        {t("common:navigation.opportunities")}
+                      </Typography>
+                    </MenuItem>
+                    <MenuItem
+                      onClick={handleCloseOpportunitiesMenu}
+                      component={Link}
+                      href="/opportunities/create"
+                    >
+                      <Typography textAlign="center">
+                        {t("common:navigation.opportunitiesCreate")}
                       </Typography>
                     </MenuItem>
                   </Menu>

--- a/src/components/opportunity/opportunities-list.tsx
+++ b/src/components/opportunity/opportunities-list.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+import Button from "@mui/material/Button";
+import IconButton from "@mui/material/IconButton";
+import DeleteIcon from "@mui/icons-material/Delete";
+import EditIcon from "@mui/icons-material/Edit";
+import { useRouter } from "next/navigation";
+import {
+  mockDeleteOpportunity,
+  mockGetOpportunities,
+} from "@/services/api/services/opportunities";
+import HTTP_CODES_ENUM from "@/services/api/types/http-codes";
+import { Opportunity } from "@/services/api/types/opportunity";
+import { useSnackbar } from "@/hooks/use-snackbar";
+
+function OpportunitiesList() {
+  const router = useRouter();
+  const fetchOpportunities = mockGetOpportunities;
+  const deleteOpportunity = mockDeleteOpportunity;
+  const { enqueueSnackbar } = useSnackbar();
+
+  const [data, setData] = useState<Opportunity[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const load = async () => {
+    setLoading(true);
+    const { status, data } = await fetchOpportunities();
+    if (status === HTTP_CODES_ENUM.OK) {
+      setData(data.data as Opportunity[]);
+    }
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    load();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleDelete = async (id: number) => {
+    const { status } = await deleteOpportunity({ id });
+    if (status === HTTP_CODES_ENUM.OK || status === HTTP_CODES_ENUM.NO_CONTENT) {
+      enqueueSnackbar("Deleted", { variant: "success" });
+      load();
+    } else {
+      enqueueSnackbar("Error", { variant: "error" });
+    }
+  };
+
+  return (
+    <>
+      <Button
+        variant="contained"
+        onClick={() => router.push("/opportunities/create")}
+        sx={{ mb: 2 }}
+      >
+        Create Opportunity
+      </Button>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell>Type</TableCell>
+            <TableCell>Clients</TableCell>
+            <TableCell>Partners</TableCell>
+            <TableCell>Created At</TableCell>
+            <TableCell>Actions</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {data.map((op) => (
+            <TableRow key={op.id} hover>
+              <TableCell>{op.type}</TableCell>
+              <TableCell>{op.clients.length} clients</TableCell>
+              <TableCell>{op.partners.length} partners</TableCell>
+              <TableCell>{op.createdAt?.slice(0, 10)}</TableCell>
+              <TableCell>
+                <IconButton
+                  size="small"
+                  onClick={() => router.push(`/opportunities/${op.id}/edit`)}
+                >
+                  <EditIcon />
+                </IconButton>
+                <IconButton size="small" onClick={() => handleDelete(op.id)}>
+                  <DeleteIcon />
+                </IconButton>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+      {loading && <p>Loading...</p>}
+    </>
+  );
+}
+
+export default OpportunitiesList;

--- a/src/components/opportunity/opportunity-form.tsx
+++ b/src/components/opportunity/opportunity-form.tsx
@@ -1,0 +1,299 @@
+"use client";
+
+import Button from "@mui/material/Button";
+import Grid from "@mui/material/Grid";
+import Drawer from "@mui/material/Drawer";
+import Typography from "@mui/material/Typography";
+import { yupResolver } from "@hookform/resolvers/yup";
+import * as yup from "yup";
+import { InferType } from "yup";
+import {
+  FormProvider,
+  useFieldArray,
+  useForm,
+  useFormState,
+} from "react-hook-form";
+import { useEffect, useState } from "react";
+import FormSelectInput from "@/components/form/select/form-select";
+import { useGetCompaniesService } from "@/services/api/services/companies";
+import { useGetUsersService } from "@/services/api/services/users";
+import {
+  mockPostOpportunity,
+  mockPutOpportunity,
+} from "@/services/api/services/opportunities";
+import { useSnackbar } from "@/hooks/use-snackbar";
+import HTTP_CODES_ENUM from "@/services/api/types/http-codes";
+import { useRouter } from "next/navigation";
+
+export const validationSchema = yup.object({
+  type: yup
+    .string()
+    .oneOf(["factoring", "reverse_factoring", "credit_insurance"])
+    .required(),
+  clients: yup
+    .array()
+    .of(
+      yup.object({
+        company: yup
+          .object({ id: yup.number().required(), name: yup.string().nullable() })
+          .required(),
+        contacts: yup
+          .array()
+          .of(
+            yup.object({
+              id: yup.number().required(),
+              name: yup.string().nullable(),
+            })
+          )
+          .min(1)
+          .required(),
+      })
+    )
+    .min(1)
+    .required(),
+  partners: yup
+    .array()
+    .of(
+      yup.object({
+        type: yup.string().oneOf(["factor", "credit_insurer"]).required(),
+        company: yup
+          .object({ id: yup.number().required(), name: yup.string().nullable() })
+          .required(),
+        contacts: yup
+          .array()
+          .of(
+            yup.object({
+              id: yup.number().required(),
+              name: yup.string().nullable(),
+            })
+          )
+          .min(1)
+          .required(),
+      })
+    )
+    .min(1)
+    .required(),
+});
+
+export type OpportunityFormData = InferType<typeof validationSchema>;
+
+const emptyClient = {
+  company: { id: 0, name: "" },
+  contacts: [{ id: 0, name: "" }],
+};
+
+const emptyPartner = {
+  type: undefined,
+  company: { id: 0, name: "" },
+  contacts: [{ id: 0, name: "" }],
+} as unknown as OpportunityFormData["partners"][number];
+
+type Props = {
+  initialValues?: OpportunityFormData & { id?: number };
+  onSuccess: () => void;
+};
+
+function OpportunityForm({ initialValues, onSuccess }: Props) {
+  const router = useRouter();
+  const { enqueueSnackbar } = useSnackbar();
+  const fetchCompanies = useGetCompaniesService();
+  const fetchUsers = useGetUsersService();
+  const postOpportunity = mockPostOpportunity;
+  const putOpportunity = mockPutOpportunity;
+
+  const [companies, setCompanies] = useState<{ id: number; name: string }[]>([]);
+  const [users, setUsers] = useState<{ id: number; name: string }[]>([]);
+  const [drawerOpen, setDrawerOpen] = useState(false); // placeholder
+
+  useEffect(() => {
+    const loadCompanies = async () => {
+      const { status, data } = await fetchCompanies({ page: 1, limit: 50 });
+      if (status === HTTP_CODES_ENUM.OK) {
+        setCompanies(data.data as { id: number; name: string }[]);
+      }
+    };
+    loadCompanies();
+  }, [fetchCompanies]);
+
+  useEffect(() => {
+    const loadUsers = async () => {
+      const { status, data } = await fetchUsers({ page: 1, limit: 50 });
+      if (status === HTTP_CODES_ENUM.OK) {
+        setUsers(data.data as { id: number; name: string }[]);
+      }
+    };
+    loadUsers();
+  }, [fetchUsers]);
+
+  const methods = useForm<OpportunityFormData>({
+    resolver: yupResolver(validationSchema),
+    defaultValues:
+      (initialValues as OpportunityFormData) ??
+      ({
+        type: undefined,
+        clients: [emptyClient],
+        partners: [emptyPartner],
+      } as unknown as OpportunityFormData),
+  });
+
+  const { control, handleSubmit, setError } = methods;
+  const { isSubmitting } = useFormState({ control });
+
+  const clientsArray = useFieldArray({ control, name: "clients" });
+  const partnersArray = useFieldArray({ control, name: "partners" });
+
+  const onSubmit = handleSubmit(async (formData) => {
+    const requestData = formData;
+    const { data, status } = initialValues?.id
+      ? await putOpportunity({ id: initialValues.id, data: requestData })
+      : await postOpportunity(requestData);
+    if (status === HTTP_CODES_ENUM.UNPROCESSABLE_ENTITY) {
+      (Object.keys(data.errors) as Array<keyof OpportunityFormData>).forEach(
+        (key) => {
+          setError(key, { type: "manual", message: data.errors[key] });
+        }
+      );
+      return;
+    }
+    if (status === HTTP_CODES_ENUM.CREATED || status === HTTP_CODES_ENUM.OK) {
+      enqueueSnackbar("Saved", { variant: "success" });
+      onSuccess();
+    }
+  });
+
+  return (
+    <FormProvider {...methods}>
+      <form onSubmit={onSubmit}>
+        <Grid container spacing={2} mb={3} mt={3}>
+          <Grid xs={12} item>
+            <FormSelectInput<OpportunityFormData, { id: string }>
+              name="type"
+              label="Type"
+              options={[
+                { id: "factoring" },
+                { id: "reverse_factoring" },
+                { id: "credit_insurance" },
+              ]}
+              keyValue="id"
+          renderOption={(opt) => opt.id}
+        />
+      </Grid>
+      <Grid item xs={12}>
+        <Typography variant="h6">Clients</Typography>
+      </Grid>
+      {clientsArray.fields.map((field, index) => (
+        <Grid key={field.id || index} container spacing={2} item xs={12}>
+          <Grid item xs={12} lg={6}>
+            <FormSelectInput<OpportunityFormData, { id: number; name: string }>
+              name={`clients.${index}.company`}
+              label="Company"
+              options={companies}
+              keyValue="id"
+              renderOption={(c) => c.name}
+            />
+          </Grid>
+          <Grid item xs={12} lg={6}>
+            <FormSelectInput<OpportunityFormData, { id: number; name: string }>
+              name={`clients.${index}.contacts.0` as never}
+              label="Contact"
+              options={users}
+              keyValue="id"
+              renderOption={(u) => u.name}
+            />
+          </Grid>
+          <Grid item xs={12}>
+            <Button
+              variant="contained"
+              color="inherit"
+              onClick={() => clientsArray.remove(index)}
+            >
+              Remove Client
+            </Button>
+          </Grid>
+        </Grid>
+      ))}
+      <Grid item xs={12}>
+        <Button
+          variant="contained"
+          onClick={() => clientsArray.append(emptyClient)}
+        >
+          Add Client
+        </Button>
+      </Grid>
+      <Grid item xs={12}>
+        <Typography variant="h6">Partners</Typography>
+      </Grid>
+      {partnersArray.fields.map((field, index) => (
+        <Grid key={field.id || index} container spacing={2} item xs={12}>
+          <Grid item xs={12} lg={6}>
+            <FormSelectInput<OpportunityFormData, { id: string }>
+              name={`partners.${index}.type`}
+              label="Partner Type"
+              options={[{ id: "factor" }, { id: "credit_insurer" }]}
+              keyValue="id"
+              renderOption={(o) => o.id}
+            />
+            <FormSelectInput<OpportunityFormData, { id: number; name: string }>
+              name={`partners.${index}.company`}
+              label="Company"
+              options={companies}
+              keyValue="id"
+              renderOption={(c) => c.name}
+            />
+          </Grid>
+          <Grid item xs={12} lg={6}>
+            <FormSelectInput<OpportunityFormData, { id: number; name: string }>
+              name={`partners.${index}.contacts.0` as never}
+              label="Contact"
+              options={users}
+              keyValue="id"
+              renderOption={(u) => u.name}
+            />
+          </Grid>
+          <Grid item xs={12}>
+            <Button
+              variant="contained"
+              color="inherit"
+              onClick={() => partnersArray.remove(index)}
+            >
+              Remove Partner
+            </Button>
+          </Grid>
+        </Grid>
+      ))}
+      <Grid item xs={12}>
+        <Button
+          variant="contained"
+          onClick={() => partnersArray.append(emptyPartner)}
+        >
+          Add Partner
+        </Button>
+      </Grid>
+      <Grid item xs={12}>
+        <Button type="submit" variant="contained" disabled={isSubmitting}>
+          Submit
+        </Button>
+        <Button
+          sx={{ ml: 1 }}
+          variant="contained"
+          color="inherit"
+          onClick={() => router.push("/opportunities")}
+        >
+          Cancel
+        </Button>
+      </Grid>
+        </Grid>
+      </form>
+      <Drawer
+        anchor="right"
+        open={drawerOpen}
+        onClose={() => setDrawerOpen(false)}
+        PaperProps={{ sx: { width: "50vw" } }}
+      >
+        {/* TODO: create company or user forms */}
+      </Drawer>
+    </FormProvider>
+  );
+}
+
+export default OpportunityForm;

--- a/src/services/api/services/opportunities.ts
+++ b/src/services/api/services/opportunities.ts
@@ -1,0 +1,195 @@
+import { useCallback } from "react";
+import useFetch from "../use-fetch";
+import { API_URL } from "../config";
+import wrapperFetchJsonResponse from "../wrapper-fetch-json-response";
+import { Opportunity } from "../types/opportunity";
+import { InfinityPaginationType } from "../types/infinity-pagination";
+import { RequestConfigType } from "./types/request-config";
+import HTTP_CODES_ENUM from "../types/http-codes";
+
+// ----- Mock data -----
+let mockOpportunities: Opportunity[] = [
+  {
+    id: 1,
+    type: "factoring",
+    clients: [
+      {
+        company: { id: 10, name: "Acme Corp" },
+        contacts: [{ id: 100, name: "Alice" }],
+      },
+      {
+        company: { id: 11, name: "Beta SA" },
+        contacts: [{ id: 101, name: "Bob" }],
+      },
+    ],
+    partners: [
+      {
+        type: "factor",
+        company: { id: 20, name: "FactorCo" },
+        contacts: [{ id: 200, name: "Charlie" }],
+      },
+    ],
+    createdAt: "2025-05-15",
+  },
+  {
+    id: 2,
+    type: "reverse_factoring",
+    clients: [
+      {
+        company: { id: 12, name: "Gamma Ltd" },
+        contacts: [{ id: 102, name: "Diane" }],
+      },
+    ],
+    partners: [
+      {
+        type: "credit_insurer",
+        company: { id: 21, name: "InsureAll" },
+        contacts: [{ id: 201, name: "Evan" }],
+      },
+    ],
+    createdAt: "2025-06-01",
+  },
+  {
+    id: 3,
+    type: "credit_insurance",
+    clients: [
+      {
+        company: { id: 13, name: "Delta LLC" },
+        contacts: [{ id: 103, name: "Frank" }],
+      },
+    ],
+    partners: [
+      {
+        type: "factor",
+        company: { id: 22, name: "FinancePlus" },
+        contacts: [{ id: 202, name: "Grace" }],
+      },
+    ],
+    createdAt: "2025-04-20",
+  },
+];
+
+export function mockGetOpportunities() {
+  return Promise.resolve({
+    status: HTTP_CODES_ENUM.OK,
+    data: { data: mockOpportunities },
+  });
+}
+
+export function mockDeleteOpportunity({ id }: { id: number }) {
+  mockOpportunities = mockOpportunities.filter((o) => o.id !== id);
+  return Promise.resolve({ status: HTTP_CODES_ENUM.OK });
+}
+
+export function mockPostOpportunity(data: OpportunityPostRequest) {
+  const newId = Math.max(0, ...mockOpportunities.map((o) => o.id)) + 1;
+  const created: Opportunity = {
+    ...data,
+    id: newId,
+    createdAt: new Date().toISOString().slice(0, 10),
+  };
+  mockOpportunities.push(created);
+  return Promise.resolve({ status: HTTP_CODES_ENUM.CREATED, data: created });
+}
+
+export function mockPutOpportunity({ id, data }: OpportunityPutRequest) {
+  const index = mockOpportunities.findIndex((o) => o.id === id);
+  if (index !== -1) {
+    mockOpportunities[index] = { ...mockOpportunities[index], ...data };
+  }
+  return Promise.resolve({ status: HTTP_CODES_ENUM.OK, data: mockOpportunities[index] });
+}
+
+export type OpportunitiesRequest = { page: number; limit: number };
+export type OpportunitiesResponse = InfinityPaginationType<Opportunity>;
+
+export function useGetOpportunitiesService() {
+  const fetch = useFetch();
+
+  return useCallback(
+    (data: OpportunitiesRequest, requestConfig?: RequestConfigType) => {
+      const requestUrl = new URL(`${API_URL}/v1/opportunities`);
+      requestUrl.searchParams.append("page", data.page.toString());
+      requestUrl.searchParams.append("limit", data.limit.toString());
+
+      return fetch(requestUrl, {
+        method: "GET",
+        ...requestConfig,
+      }).then(wrapperFetchJsonResponse<OpportunitiesResponse>);
+    },
+    [fetch]
+  );
+}
+
+export type OpportunityRequest = { id: Opportunity["id"] };
+export type OpportunityResponse = Opportunity;
+
+export function useGetOpportunityService() {
+  const fetch = useFetch();
+
+  return useCallback(
+    (data: OpportunityRequest, requestConfig?: RequestConfigType) => {
+      return fetch(`${API_URL}/v1/opportunities/${data.id}`, {
+        method: "GET",
+        ...requestConfig,
+      }).then(wrapperFetchJsonResponse<OpportunityResponse>);
+    },
+    [fetch]
+  );
+}
+
+export type OpportunityPostRequest = Omit<Opportunity, "id" | "createdAt">;
+export type OpportunityPostResponse = Opportunity;
+
+export function usePostOpportunityService() {
+  const fetch = useFetch();
+
+  return useCallback(
+    (data: OpportunityPostRequest, requestConfig?: RequestConfigType) => {
+      return fetch(`${API_URL}/v1/opportunities`, {
+        method: "POST",
+        body: JSON.stringify(data),
+        ...requestConfig,
+      }).then(wrapperFetchJsonResponse<OpportunityPostResponse>);
+    },
+    [fetch]
+  );
+}
+
+export type OpportunityPutRequest = {
+  id: Opportunity["id"];
+  data: OpportunityPostRequest;
+};
+export type OpportunityPutResponse = Opportunity;
+
+export function usePutOpportunityService() {
+  const fetch = useFetch();
+
+  return useCallback(
+    (data: OpportunityPutRequest, requestConfig?: RequestConfigType) => {
+      return fetch(`${API_URL}/v1/opportunities/${data.id}`, {
+        method: "PUT",
+        body: JSON.stringify(data.data),
+        ...requestConfig,
+      }).then(wrapperFetchJsonResponse<OpportunityPutResponse>);
+    },
+    [fetch]
+  );
+}
+
+export type OpportunityDeleteRequest = { id: Opportunity["id"] };
+export type OpportunityDeleteResponse = undefined;
+
+export function useDeleteOpportunityService() {
+  const fetch = useFetch();
+
+  return useCallback(
+    (data: OpportunityDeleteRequest, requestConfig?: RequestConfigType) => {
+      return fetch(`${API_URL}/v1/opportunities/${data.id}`, {
+        method: "DELETE",
+        ...requestConfig,
+      }).then(wrapperFetchJsonResponse<OpportunityDeleteResponse>);
+    },
+    [fetch]
+  );
+}

--- a/src/services/api/types/opportunity.ts
+++ b/src/services/api/types/opportunity.ts
@@ -1,0 +1,18 @@
+export type OpportunityPartner = {
+  type: "factor" | "credit_insurer";
+  company: { id: number; name?: string | null };
+  contacts: { id: number; name?: string | null }[];
+};
+
+export type OpportunityClient = {
+  company: { id: number; name?: string | null };
+  contacts: { id: number; name?: string | null }[];
+};
+
+export type Opportunity = {
+  id: number;
+  type: "factoring" | "reverse_factoring" | "credit_insurance";
+  clients: OpportunityClient[];
+  partners: OpportunityPartner[];
+  createdAt: string;
+};

--- a/src/services/i18n/locales/en/common.json
+++ b/src/services/i18n/locales/en/common.json
@@ -10,6 +10,8 @@
     "usersCreate": "Create User",
     "companies": "Companies",
     "companiesCreate": "Create Company",
+    "opportunities": "Opportunities",
+    "opportunitiesCreate": "Create Opportunity",
     "logout": "Logout"
   },
   "formInputs": {

--- a/src/services/i18n/locales/en/opportunities.json
+++ b/src/services/i18n/locales/en/opportunities.json
@@ -1,0 +1,5 @@
+{
+  "title": "Opportunities",
+  "create": "Create Opportunity",
+  "edit": "Edit Opportunity"
+}


### PR DESCRIPTION
## Summary
- mock a sample opportunities dataset and CRUD helpers
- show opportunities list with initial mock data
- update opportunity form layout with responsive sections
- translate and link opportunities in navigation menus

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683dcba67d688322b7df826b993eccf7