### PR TITLE
Add drawer forms for company and user creation

### DIFF
--- a/src/app/[language]/admin-panel/users/create/page-content.tsx
+++ b/src/app/[language]/admin-panel/users/create/page-content.tsx
@@ -27,9 +27,7 @@ import { Role, RoleEnum } from "@/services/api/types/role";
 import FormSelectInput from "@/components/form/select/form-select";
 import FormPhoneInput from "@/components/form/phone-input/form-phone-input";
 import FormCheckboxBooleanInput from "@/components/form/checkbox-boolean/form-checkbox-boolean";
-import CreateCompany, {
-  FormCreate,
-} from "@/app/[language]/admin-panel/companies/create/page-content";
+import CreateCompanyForm from "@/components/create-company-form";
 
 const serviceOptions = [
   { id: "Management" },
@@ -180,12 +178,14 @@ function FormCreateUser() {
     },
   });
 
-  const { handleSubmit, setError } = methods;
+  const { handleSubmit, setError, setValue } = methods;
 
   const handleDrawerClose = () => setDrawerOpen(false);
 
-  const handleCompanyCreated = async () => {
+  const handleCompanyCreated = async (company: Company) => {
     await loadCompanies();
+    setValue("company.id", company.id);
+    setValue("company.name", company.name);
     handleDrawerClose();
   };
 
@@ -366,7 +366,10 @@ function FormCreateUser() {
         onClose={handleDrawerClose}
         PaperProps={{ sx: { width: "50vw" } }}
       >
-        <FormCreate onSuccess={handleCompanyCreated} />
+        <CreateCompanyForm
+          onSuccess={handleCompanyCreated}
+          onCancel={handleDrawerClose}
+        />
       </Drawer>
     </FormProvider>
   );

--- a/src/app/[language]/admin-panel/users/edit/[id]/page-content.tsx
+++ b/src/app/[language]/admin-panel/users/edit/[id]/page-content.tsx
@@ -30,7 +30,7 @@ import FormPhoneInput from "@/components/form/phone-input/form-phone-input";
 import FormCheckboxBooleanInput from "@/components/form/checkbox-boolean/form-checkbox-boolean";
 import { useGetCompaniesService } from "@/services/api/services/companies";
 import { Company } from "@/services/api/types/company";
-import { FormCreate } from "@/app/[language]/admin-panel/companies/create/page-content";
+import CreateCompanyForm from "@/components/create-company-form";
 
 const serviceOptions = [
   { id: "Management" },
@@ -200,12 +200,14 @@ function FormEditUser() {
     },
   });
 
-  const { handleSubmit, setError, reset } = methods;
+  const { handleSubmit, setError, reset, setValue } = methods;
 
   const handleDrawerClose = () => setDrawerOpen(false);
 
-  const handleCompanyCreated = async () => {
+  const handleCompanyCreated = async (company: Company) => {
     await loadCompanies();
+    setValue("company.id", company.id);
+    setValue("company.name", company.name);
     handleDrawerClose();
   };
 
@@ -397,7 +399,10 @@ function FormEditUser() {
         onClose={handleDrawerClose}
         PaperProps={{ sx: { width: "50vw" } }}
       >
-        <FormCreate onSuccess={handleCompanyCreated} />
+        <CreateCompanyForm
+          onSuccess={handleCompanyCreated}
+          onCancel={handleDrawerClose}
+        />
       </Drawer>
     </FormProvider>
   );

--- a/src/components/create-user-form.tsx
+++ b/src/components/create-user-form.tsx
@@ -9,23 +9,24 @@ import FormTextInput from "@/components/form/text-input/form-text-input";
 import { useTranslation } from "@/services/i18n/client";
 import { FC } from "react";
 
-type Company = { id: number; name: string };
+export type SimpleUser = { id: number; firstName: string; lastName: string };
 
 type Props = {
-  onSuccess?: (company: Company) => void;
+  onSuccess?: (user: SimpleUser) => void;
   onCancel?: () => void;
 };
 
 const validationSchema = yup.object({
-  name: yup.string().required(),
+  firstName: yup.string().required(),
+  lastName: yup.string().required(),
 });
 
-const CreateCompanyForm: FC<Props> = ({ onSuccess, onCancel }) => {
-  const { t } = useTranslation("admin-panel-companies-create");
+const CreateUserForm: FC<Props> = ({ onSuccess, onCancel }) => {
+  const { t } = useTranslation("admin-panel-users-create");
 
-  const methods = useForm<{ name: string }>({
+  const methods = useForm<{ firstName: string; lastName: string }>({
     resolver: yupResolver(validationSchema),
-    defaultValues: { name: "" },
+    defaultValues: { firstName: "", lastName: "" },
   });
 
   const { handleSubmit, setError } = methods;
@@ -33,10 +34,14 @@ const CreateCompanyForm: FC<Props> = ({ onSuccess, onCancel }) => {
 
   const submit = handleSubmit(async (data) => {
     try {
-      const newCompany = { id: Date.now(), name: data.name };
-      onSuccess?.(newCompany);
+      const newUser: SimpleUser = {
+        id: Date.now(),
+        firstName: data.firstName,
+        lastName: data.lastName,
+      };
+      onSuccess?.(newUser);
     } catch (e) {
-      setError("name", { type: "manual", message: String(e) });
+      setError("firstName", { type: "manual", message: String(e) });
     }
   });
 
@@ -45,7 +50,16 @@ const CreateCompanyForm: FC<Props> = ({ onSuccess, onCancel }) => {
       <form onSubmit={submit}>
         <Grid container spacing={2} p={2} width={{ xs: "80vw", sm: "50vw" }}>
           <Grid item xs={12}>
-            <FormTextInput name="name" label={t("inputs.name.label") || "Name"} />
+            <FormTextInput
+              name="firstName"
+              label={t("inputs.firstName.label") || "First Name"}
+            />
+          </Grid>
+          <Grid item xs={12}>
+            <FormTextInput
+              name="lastName"
+              label={t("inputs.lastName.label") || "Last Name"}
+            />
           </Grid>
           <Grid item xs={12} sx={{ display: "flex", gap: 1 }}>
             <Button type="submit" variant="contained" disabled={isSubmitting}>
@@ -66,4 +80,4 @@ const CreateCompanyForm: FC<Props> = ({ onSuccess, onCancel }) => {
   );
 };
 
-export default CreateCompanyForm;
+export default CreateUserForm;

--- a/src/components/opportunity/client-item.tsx
+++ b/src/components/opportunity/client-item.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useState } from "react";
 import { useFieldArray, useFormContext, useFormState } from "react-hook-form";
 import Grid from "@mui/material/Grid";
 import Button from "@mui/material/Button";
@@ -12,6 +12,8 @@ import Box from "@mui/material/Box";
 import FormSelectInput from "@/components/form/select/form-select";
 import { OpportunityFormData } from "./opportunity-form";
 import { useTranslation } from "@/services/i18n/client";
+import Drawer from "@mui/material/Drawer";
+import CreateUserForm, { SimpleUser } from "@/components/create-user-form";
 
 type User = { id: number; firstName: string; lastName: string };
 
@@ -29,7 +31,8 @@ export function ClientItem({
   onRemove,
 }: ClientItemProps) {
   // Accès au contexte du formulaire
-  const { control } = useFormContext<OpportunityFormData>();
+  const { control, setValue } = useFormContext<OpportunityFormData>();
+  const [drawerContactIndex, setDrawerContactIndex] = useState<number | null>(null);
   const { t } = useTranslation("opportunities");
 
   // Champ “contacts” (FieldArray imbriqué) pour ce client
@@ -91,9 +94,7 @@ export function ClientItem({
 
         <Button
           size="small"
-          onClick={() => {
-            // TODO : ouvrir le Drawer “Create User”
-          }}
+          onClick={() => setDrawerContactIndex(contactFields.length - 1)}
         >
           {t("form.clients.createUserButton")}
         </Button>
@@ -111,17 +112,39 @@ export function ClientItem({
       </Grid>
 
       {/* Remove Client Button */}
-      {clientIndex > 0 && (
-        <Grid size={12} sx={{ display: "flex", justifyContent: "end" }}>
-          <Button
-            variant="contained"
-            color="error"
-            onClick={() => onRemove(clientIndex)}
-          >
-            {t("form.clients.removeButton")}
-          </Button>
-        </Grid>
-      )}
+  {clientIndex > 0 && (
+    <Grid size={12} sx={{ display: "flex", justifyContent: "end" }}>
+      <Button
+        variant="contained"
+        color="error"
+        onClick={() => onRemove(clientIndex)}
+      >
+        {t("form.clients.removeButton")}
+      </Button>
     </Grid>
+  )}
+  </Grid>
+  <Drawer
+    anchor="right"
+    open={drawerContactIndex !== null}
+    onClose={() => setDrawerContactIndex(null)}
+    PaperProps={{ sx: { width: "50vw" } }}
+  >
+    <CreateUserForm
+      onSuccess={(user) => {
+        if (drawerContactIndex === null) return;
+        setValue(
+          `clients.${clientIndex}.contacts.${drawerContactIndex}.id`,
+          user.id
+        );
+        setValue(
+          `clients.${clientIndex}.contacts.${drawerContactIndex}.name`,
+          `${user.firstName} ${user.lastName}`
+        );
+        setDrawerContactIndex(null);
+      }}
+      onCancel={() => setDrawerContactIndex(null)}
+    />
+  </Drawer>
   );
 }

--- a/src/components/opportunity/opportunity-form.tsx
+++ b/src/components/opportunity/opportunity-form.tsx
@@ -2,7 +2,6 @@
 
 import Button from "@mui/material/Button";
 import Grid from "@mui/material/Grid";
-import Drawer from "@mui/material/Drawer";
 import Typography from "@mui/material/Typography";
 import { yupResolver } from "@hookform/resolvers/yup";
 import * as yup from "yup";
@@ -104,7 +103,6 @@ export default function OpportunityForm({ initialValues, onSuccess }: Props) {
   const { t } = useTranslation("opportunities");
   const postOpportunity = mockPostOpportunity;
   const putOpportunity = mockPutOpportunity;
-  const [drawerOpen, setDrawerOpen] = useState(false);
 
   const methods = useForm<OpportunityFormData>({
     resolver: yupResolver(validationSchema),
@@ -198,14 +196,7 @@ export default function OpportunityForm({ initialValues, onSuccess }: Props) {
         </Grid>
       </form>
 
-      <Drawer
-        anchor="right"
-        open={drawerOpen}
-        onClose={() => setDrawerOpen(false)}
-        PaperProps={{ sx: { width: "50vw" } }}
-      >
-        {/* TODO: create company or user forms */}
-      </Drawer>
+      {/* Drawers handled in sub components */}
     </FormProvider>
   );
 }

--- a/src/components/opportunity/partner-field-array.tsx
+++ b/src/components/opportunity/partner-field-array.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useCallback } from "react";
 import { useFieldArray, useFormContext, useFormState } from "react-hook-form";
 import Grid from "@mui/material/Grid";
 import Box from "@mui/material/Box";
@@ -14,6 +14,8 @@ import { useGetCompaniesService } from "@/services/api/services/companies";
 import { useGetUsersService } from "@/services/api/services/users";
 import HTTP_CODES_ENUM from "@/services/api/types/http-codes";
 import { useTranslation } from "@/services/i18n/client";
+import Drawer from "@mui/material/Drawer";
+import CreateCompanyForm from "@/components/create-company-form";
 
 type Company = { id: number; name: string };
 type User = { id: number; name: string };
@@ -32,32 +34,43 @@ export function PartnerFieldArray({ emptyPartner }: PartnerFieldArrayProps) {
   const fetchUsers = useGetUsersService();
   const [companies, setCompanies] = useState<Company[]>([]);
   const [users, setUsers] = useState<User[]>([]);
-  const { control } = useFormContext<OpportunityFormData>();
+  const [companyDrawerIndex, setCompanyDrawerIndex] = useState<number | null>(null);
+  const { control, setValue } = useFormContext<OpportunityFormData>();
   const { fields, append, remove } = useFieldArray({
     name: "partners",
     control,
   });
   const { errors } = useFormState({ control });
 
-  useEffect(() => {
-    const loadCompanies = async () => {
-      const { status, data } = await fetchCompanies({ page: 1, limit: 50 });
-      if (status === HTTP_CODES_ENUM.OK) {
-        setCompanies(data.data as Company[]);
-      }
-    };
-    loadCompanies();
+  const loadCompanies = useCallback(async () => {
+    const { status, data } = await fetchCompanies({ page: 1, limit: 50 });
+    if (status === HTTP_CODES_ENUM.OK) {
+      setCompanies(data.data as Company[]);
+    }
   }, [fetchCompanies]);
 
-  useEffect(() => {
-    const loadUsers = async () => {
-      const { status, data } = await fetchUsers({ page: 1, limit: 50 });
-      if (status === HTTP_CODES_ENUM.OK) {
-        setUsers(data.data as User[]);
-      }
-    };
-    loadUsers();
+  const loadUsers = useCallback(async () => {
+    const { status, data } = await fetchUsers({ page: 1, limit: 50 });
+    if (status === HTTP_CODES_ENUM.OK) {
+      setUsers(data.data as User[]);
+    }
   }, [fetchUsers]);
+
+  useEffect(() => {
+    loadCompanies();
+  }, [loadCompanies]);
+
+  useEffect(() => {
+    loadUsers();
+  }, [loadUsers]);
+
+  const handleCompanyCreated = async (company: Company) => {
+    if (companyDrawerIndex === null) return;
+    await loadCompanies();
+    setValue(`partners.${companyDrawerIndex}.company.id`, company.id);
+    setValue(`partners.${companyDrawerIndex}.company.name`, company.name);
+    setCompanyDrawerIndex(null);
+  };
 
   return (
     <>
@@ -92,9 +105,7 @@ export function PartnerFieldArray({ emptyPartner }: PartnerFieldArrayProps) {
               <Button
                 size="small"
                 sx={{ mt: 1 }}
-                onClick={() => {
-                  /* TODO: open Create Company drawer */
-                }}
+                onClick={() => setCompanyDrawerIndex(index)}
               >
                 {t("form.partners.createCompanyButton")}
               </Button>
@@ -127,6 +138,17 @@ export function PartnerFieldArray({ emptyPartner }: PartnerFieldArrayProps) {
           {t("form.partners.addButton")}
         </Button>
       </Grid>
+      <Drawer
+        anchor="right"
+        open={companyDrawerIndex !== null}
+        onClose={() => setCompanyDrawerIndex(null)}
+        PaperProps={{ sx: { width: "50vw" } }}
+      >
+        <CreateCompanyForm
+          onSuccess={handleCompanyCreated}
+          onCancel={() => setCompanyDrawerIndex(null)}
+        />
+      </Drawer>
     </>
   );
 }

--- a/src/components/opportunity/partner-item.tsx
+++ b/src/components/opportunity/partner-item.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useState } from "react";
 import { useFieldArray, useFormContext, useFormState } from "react-hook-form";
 import Grid from "@mui/material/Grid";
 import Box from "@mui/material/Box";
@@ -12,6 +12,8 @@ import Typography from "@mui/material/Typography";
 import FormSelectInput from "@/components/form/select/form-select";
 import { OpportunityFormData } from "./opportunity-form";
 import { useTranslation } from "@/services/i18n/client";
+import Drawer from "@mui/material/Drawer";
+import CreateUserForm from "@/components/create-user-form";
 
 type User = { id: number; name: string };
 
@@ -28,8 +30,9 @@ export function PartnerItem({
   users,
   onRemove,
 }: PartnerItemProps) {
-  const { control } = useFormContext<OpportunityFormData>();
+  const { control, setValue } = useFormContext<OpportunityFormData>();
   const { t } = useTranslation("opportunities");
+  const [drawerContactIndex, setDrawerContactIndex] = useState<number | null>(null);
   const {
     fields: contactFields,
     append: appendContact,
@@ -77,9 +80,7 @@ export function PartnerItem({
           </Button>
           <Button
             size="small"
-            onClick={() => {
-              /* TODO: open Create User drawer */
-            }}
+            onClick={() => setDrawerContactIndex(contactFields.length - 1)}
           >
             {t("form.partners.createUserButton")}
           </Button>
@@ -94,17 +95,39 @@ export function PartnerItem({
             </Typography>
           </Grid>
         )}
-      {partnerIndex > 0 && (
-        <Grid item xs={12} sx={{ display: "flex", justifyContent: "end" }}>
-          <Button
-            variant="contained"
-            color="error"
-            onClick={() => onRemove(partnerIndex)}
-          >
-            {t("form.partners.removeButton")}
-          </Button>
-        </Grid>
-      )}
+  {partnerIndex > 0 && (
+    <Grid item xs={12} sx={{ display: "flex", justifyContent: "end" }}>
+      <Button
+        variant="contained"
+        color="error"
+        onClick={() => onRemove(partnerIndex)}
+      >
+        {t("form.partners.removeButton")}
+      </Button>
     </Grid>
+  )}
+  </Grid>
+  <Drawer
+    anchor="right"
+    open={drawerContactIndex !== null}
+    onClose={() => setDrawerContactIndex(null)}
+    PaperProps={{ sx: { width: "50vw" } }}
+  >
+    <CreateUserForm
+      onSuccess={(user) => {
+        if (drawerContactIndex === null) return;
+        setValue(
+          `partners.${partnerIndex}.contacts.${drawerContactIndex}.id`,
+          user.id
+        );
+        setValue(
+          `partners.${partnerIndex}.contacts.${drawerContactIndex}.name`,
+          user.name || ""
+        );
+        setDrawerContactIndex(null);
+      }}
+      onCancel={() => setDrawerContactIndex(null)}
+    />
+  </Drawer>
   );
 }


### PR DESCRIPTION
## Summary
- implement `CreateCompanyForm` and new `CreateUserForm`
- use drawers on user create/edit pages to create a company
- add company/user drawer handling for opportunity forms

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ef9dfdf18832288fc142569d5c6b3