### PR TITLE
Add contacts CRUD

### DIFF
--- a/src/app/[language]/admin-panel/contacts/[id]/edit/page-content.tsx
+++ b/src/app/[language]/admin-panel/contacts/[id]/edit/page-content.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import withPageRequiredAuth from "@/services/auth/with-page-required-auth";
+import { RoleEnum } from "@/services/api/types/role";
+import ContactForm from "@/components/form/contact-form";
+import { useRouter, useParams } from "next/navigation";
+import { useSnackbar } from "@/hooks/use-snackbar";
+import { useTranslation } from "@/services/i18n/client";
+import { useEffect, useState } from "react";
+import { useGetContactByIdService } from "@/services/api/services/contacts";
+import { ContactFormData } from "@/services/api/types/contact";
+import HTTP_CODES_ENUM from "@/services/api/types/http-codes";
+
+function EditContactPage() {
+  const router = useRouter();
+  const params = useParams<{ id: string }>();
+  const id = params.id;
+  const { enqueueSnackbar } = useSnackbar();
+  const { t } = useTranslation("contacts");
+  const fetchContact = useGetContactByIdService();
+  const [initialValues, setInitialValues] = useState<ContactFormData | undefined>();
+
+  useEffect(() => {
+    (async () => {
+      const { status, data } = await fetchContact({ id });
+      if (status === HTTP_CODES_ENUM.OK) {
+        setInitialValues({
+          email: data.email,
+          phone: data.phone,
+          firstname: data.firstname,
+          lastname: data.lastname,
+          birthdate: data.birthdate,
+          job: data.job,
+          companies: data.companies,
+        });
+      }
+    })();
+  }, [fetchContact, id]);
+
+  if (!initialValues) return null;
+
+  return (
+    <ContactForm
+      initialValues={initialValues}
+      onSuccess={() => {
+        enqueueSnackbar(t("alerts.updated"), { variant: "success" });
+        router.push("/admin-panel/contacts");
+      }}
+    />
+  );
+}
+
+export default withPageRequiredAuth(EditContactPage, { roles: [RoleEnum.ADMIN] });

--- a/src/app/[language]/admin-panel/contacts/[id]/edit/page.tsx
+++ b/src/app/[language]/admin-panel/contacts/[id]/edit/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import PageContent from "./page-content";
+import { getServerTranslation } from "@/services/i18n";
+
+type Props = { params: Promise<{ language: string }> };
+
+export async function generateMetadata(props: Props): Promise<Metadata> {
+  const params = await props.params;
+  const { t } = await getServerTranslation(params.language, "contacts");
+  return { title: t("title.edit") };
+}
+
+export default function Page() {
+  return <PageContent />;
+}

--- a/src/app/[language]/admin-panel/contacts/create/page-content.tsx
+++ b/src/app/[language]/admin-panel/contacts/create/page-content.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import withPageRequiredAuth from "@/services/auth/with-page-required-auth";
+import { RoleEnum } from "@/services/api/types/role";
+import ContactForm from "@/components/form/contact-form";
+import { useRouter } from "next/navigation";
+import { useSnackbar } from "@/hooks/use-snackbar";
+import { useTranslation } from "@/services/i18n/client";
+
+function CreateContactPage() {
+  const router = useRouter();
+  const { enqueueSnackbar } = useSnackbar();
+  const { t } = useTranslation("contacts");
+
+  return (
+    <ContactForm
+      onSuccess={() => {
+        enqueueSnackbar(t("alerts.created"), { variant: "success" });
+        router.push("/admin-panel/contacts");
+      }}
+    />
+  );
+}
+
+export default withPageRequiredAuth(CreateContactPage, { roles: [RoleEnum.ADMIN] });

--- a/src/app/[language]/admin-panel/contacts/create/page.tsx
+++ b/src/app/[language]/admin-panel/contacts/create/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import PageContent from "./page-content";
+import { getServerTranslation } from "@/services/i18n";
+
+type Props = { params: Promise<{ language: string }> };
+
+export async function generateMetadata(props: Props): Promise<Metadata> {
+  const params = await props.params;
+  const { t } = await getServerTranslation(params.language, "contacts");
+  return { title: t("title.create") };
+}
+
+export default function Page() {
+  return <PageContent />;
+}

--- a/src/app/[language]/admin-panel/contacts/page-content.tsx
+++ b/src/app/[language]/admin-panel/contacts/page-content.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import withPageRequiredAuth from "@/services/auth/with-page-required-auth";
+import { RoleEnum } from "@/services/api/types/role";
+import ContactList from "@/components/list/contact-list";
+
+function PageContent() {
+  return <ContactList />;
+}
+
+export default withPageRequiredAuth(PageContent, { roles: [RoleEnum.ADMIN] });

--- a/src/app/[language]/admin-panel/contacts/page.tsx
+++ b/src/app/[language]/admin-panel/contacts/page.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from "next";
+import PageContent from "./page-content";
+import { getServerTranslation } from "@/services/i18n";
+
+type Props = {
+  params: Promise<{ language: string }>;
+};
+
+export async function generateMetadata(props: Props): Promise<Metadata> {
+  const params = await props.params;
+  const { t } = await getServerTranslation(params.language, "contacts");
+  return { title: t("title.list") };
+}
+
+export default function Page() {
+  return <PageContent />;
+}

--- a/src/app/[language]/admin-panel/contacts/queries/queries.ts
+++ b/src/app/[language]/admin-panel/contacts/queries/queries.ts
@@ -1,0 +1,41 @@
+import { useGetContactsService } from "@/services/api/services/contacts";
+import HTTP_CODES_ENUM from "@/services/api/types/http-codes";
+import { createQueryKeys } from "@/services/react-query/query-key-factory";
+import { useInfiniteQuery } from "@tanstack/react-query";
+
+export const contactsQueryKeys = createQueryKeys(["contacts"], {
+  list: () => ({
+    key: [],
+  }),
+});
+
+export const useGetContactsQuery = () => {
+  const fetch = useGetContactsService();
+
+  const query = useInfiniteQuery({
+    queryKey: contactsQueryKeys.list().key,
+    initialPageParam: 1,
+    queryFn: async ({ pageParam, signal }) => {
+      const { status, data } = await fetch(
+        {
+          page: pageParam,
+          limit: 10,
+        },
+        { signal }
+      );
+
+      if (status === HTTP_CODES_ENUM.OK) {
+        return {
+          data: data.data,
+          nextPage: data.hasNextPage ? pageParam + 1 : undefined,
+        };
+      }
+    },
+    getNextPageParam: (lastPage) => {
+      return lastPage?.nextPage;
+    },
+    gcTime: 0,
+  });
+
+  return query;
+};

--- a/src/components/form/contact-form.tsx
+++ b/src/components/form/contact-form.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import Button from "@mui/material/Button";
+import Grid from "@mui/material/Grid";
+import Typography from "@mui/material/Typography";
+import { FormProvider, useForm } from "react-hook-form";
+import { yupResolver } from "@hookform/resolvers/yup";
+import * as yup from "yup";
+import { useTranslation } from "@/services/i18n/client";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import FormTextInput from "@/components/form/text-input/form-text-input";
+import FormPhoneInput from "@/components/form/phone-input/form-phone-input";
+import FormDatePickerInput from "@/components/form/date-pickers/date-picker";
+import FormSelectInput from "@/components/form/select/form-select";
+import { useGetCompaniesService } from "@/services/api/services/companies";
+import { Company } from "@/services/api/types/company";
+import { ContactFormData } from "@/services/api/types/contact";
+import {
+  usePostContactService,
+  usePutContactService,
+} from "@/services/api/services/contacts";
+import HTTP_CODES_ENUM from "@/services/api/types/http-codes";
+import { useSnackbar } from "@/hooks/use-snackbar";
+
+const useValidationSchema = () => {
+  const { t } = useTranslation("contacts");
+
+  return yup.object({
+    email: yup
+      .string()
+      .email(t("validation.required"))
+      .required(t("validation.required")),
+    phone: yup.string().required(t("validation.required")),
+    firstname: yup.string().required(t("validation.required")),
+    lastname: yup.string().required(t("validation.required")),
+    birthdate: yup.date().nullable().notRequired(),
+    job: yup.string().required(t("validation.required")),
+    companies: yup
+      .array()
+      .of(
+        yup.object({ id: yup.number().required(), name: yup.string().required() })
+      )
+      .min(1, t("validation.minCompanies"))
+      .required(t("validation.minCompanies")),
+  });
+};
+
+export default function ContactForm({
+  initialValues,
+  onSuccess,
+}: {
+  initialValues?: ContactFormData & { id?: number };
+  onSuccess: () => void;
+}) {
+  const router = useRouter();
+  const { enqueueSnackbar } = useSnackbar();
+  const { t } = useTranslation("contacts");
+  const schema = useValidationSchema();
+  const postContact = usePostContactService();
+  const putContact = usePutContactService();
+  const fetchCompanies = useGetCompaniesService();
+  const [companies, setCompanies] = useState<Company[]>([]);
+
+  useEffect(() => {
+    (async () => {
+      const { status, data } = await fetchCompanies({ page: 1, limit: 50 });
+      if (status === HTTP_CODES_ENUM.OK) {
+        setCompanies(data.data);
+      }
+    })();
+  }, [fetchCompanies]);
+
+  const methods = useForm<ContactFormData>({
+    resolver: yupResolver(schema),
+    defaultValues:
+      initialValues ?? {
+        email: "",
+        phone: "",
+        firstname: "",
+        lastname: "",
+        birthdate: undefined,
+        job: "",
+        companies: [],
+      },
+  });
+
+  const { handleSubmit, setError } = methods;
+
+  const onSubmit = handleSubmit(async (formData) => {
+    const { data, status } = initialValues?.id
+      ? await putContact({ id: initialValues.id, data: formData })
+      : await postContact(formData);
+
+    if (status === HTTP_CODES_ENUM.UNPROCESSABLE_ENTITY) {
+      (Object.keys(data.errors) as Array<keyof ContactFormData>).forEach((key) => {
+        setError(key, { type: "manual", message: data.errors[key] });
+      });
+      return;
+    }
+
+    if (status === HTTP_CODES_ENUM.CREATED || status === HTTP_CODES_ENUM.OK) {
+      enqueueSnackbar(
+        initialValues ? t("alerts.updated") : t("alerts.created"),
+        { variant: "success" }
+      );
+      onSuccess();
+    }
+  });
+
+  return (
+    <FormProvider {...methods}>
+      <form onSubmit={onSubmit} autoComplete="off">
+        <Grid container spacing={2} mb={3} mt={3}>
+          <Grid size={{ xs: 12 }}>
+            <Typography variant="h6">
+              {initialValues ? t("title.edit") : t("title.create")}
+            </Typography>
+          </Grid>
+          <Grid size={{ xs: 12 }}>
+            <FormTextInput<ContactFormData>
+              name="email"
+              label={t("form.email.label")}
+            />
+          </Grid>
+          <Grid size={{ xs: 12 }}>
+            <FormTextInput<ContactFormData>
+              name="firstname"
+              label={t("form.firstname.label")}
+            />
+          </Grid>
+          <Grid size={{ xs: 12 }}>
+            <FormTextInput<ContactFormData>
+              name="lastname"
+              label={t("form.lastname.label")}
+            />
+          </Grid>
+          <Grid size={{ xs: 12 }}>
+            <FormPhoneInput<ContactFormData>
+              name="phone"
+              label={t("form.phone.label")}
+            />
+          </Grid>
+          <Grid size={{ xs: 12 }}>
+            <FormDatePickerInput<ContactFormData>
+              name="birthdate"
+              label={t("form.birthdate.label")}
+            />
+          </Grid>
+          <Grid size={{ xs: 12 }}>
+            <FormTextInput<ContactFormData>
+              name="job"
+              label={t("form.job.label")}
+            />
+          </Grid>
+          <Grid size={{ xs: 12 }}>
+            <FormSelectInput<ContactFormData, Company>
+              name="companies"
+              label={t("form.companies.label")}
+              options={companies}
+              multiple
+              keyValue="id"
+              renderOption={(c) => c.name}
+            />
+          </Grid>
+          <Grid size={{ xs: 12 }}>
+            <Button type="submit" variant="contained">
+              {t("buttons.submit")}
+            </Button>
+            <Button
+              sx={{ ml: 1 }}
+              variant="contained"
+              color="inherit"
+              onClick={() => router.push("/admin-panel/contacts")}
+            >
+              {t("buttons.cancel")}
+            </Button>
+          </Grid>
+        </Grid>
+      </form>
+    </FormProvider>
+  );
+}

--- a/src/components/list/contact-list.tsx
+++ b/src/components/list/contact-list.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import Container from "@mui/material/Container";
+import Grid from "@mui/material/Grid";
+import Typography from "@mui/material/Typography";
+import Button from "@mui/material/Button";
+import TableCell from "@mui/material/TableCell";
+import TableRow from "@mui/material/TableRow";
+import LinearProgress from "@mui/material/LinearProgress";
+import { TableVirtuoso } from "react-virtuoso";
+import TableComponents from "@/components/table/table-components";
+import { useTranslation } from "@/services/i18n/client";
+import Link from "@/components/link";
+import useConfirmDialog from "@/components/confirm-dialog/use-confirm-dialog";
+import { useDeleteContactService } from "@/services/api/services/contacts";
+import { InfiniteData, useQueryClient } from "@tanstack/react-query";
+import { contactsQueryKeys, useGetContactsQuery } from "@/app/[language]/admin-panel/contacts/queries/queries";
+
+export default function ContactList() {
+  const { t } = useTranslation("contacts");
+  const query = useGetContactsQuery();
+  const deleteContact = useDeleteContactService();
+  const { confirmDialog } = useConfirmDialog();
+  const queryClient = useQueryClient();
+
+  const handleDelete = async (id: number) => {
+    const isConfirmed = await confirmDialog({
+      title: t("confirm.delete.title"),
+      message: t("confirm.delete.message"),
+    });
+
+    if (isConfirmed) {
+      const previousData = queryClient.getQueryData<
+        InfiniteData<{ nextPage: number; data: any[] }>
+      >(contactsQueryKeys.list().key);
+
+      await queryClient.cancelQueries({ queryKey: contactsQueryKeys.list().key });
+
+      const newData = {
+        ...previousData,
+        pages: previousData?.pages.map((page) => ({
+          ...page,
+          data: page?.data.filter((item) => item.id !== id),
+        })),
+      };
+
+      queryClient.setQueryData(contactsQueryKeys.list().key, newData);
+
+      await deleteContact({ id });
+    }
+  };
+
+  const { fetchNextPage } = query;
+
+  return (
+    <Container maxWidth="md">
+      <Grid container spacing={3} wrap="nowrap" pt={3}>
+        <Grid size={12}>
+          <Typography variant="h3" gutterBottom>
+            {t("title.list")}
+          </Typography>
+          <Button
+            variant="contained"
+            color="primary"
+            LinkComponent={Link}
+            href="/admin-panel/contacts/create"
+          >
+            {t("title.create")}
+          </Button>
+        </Grid>
+        <Grid size={12}>
+          <TableVirtuoso
+            data={query.data?.pages?.flatMap((page) => page?.data) || []}
+            components={TableComponents}
+            endReached={fetchNextPage}
+            itemContent={(index, contact) => (
+              <>
+                <TableCell>{contact?.email}</TableCell>
+                <TableCell>{contact?.firstname}</TableCell>
+                <TableCell>{contact?.lastname}</TableCell>
+                <TableCell>{contact?.phone}</TableCell>
+                <TableCell>{contact?.job}</TableCell>
+                <TableCell>{contact?.companies?.length}</TableCell>
+                <TableCell>
+                  <Button
+                    size="small"
+                    color="primary"
+                    variant="contained"
+                    LinkComponent={Link}
+                    href={`/admin-panel/contacts/${contact?.id}/edit`}
+                  >
+                    {t("actions.edit")}
+                  </Button>
+                  <Button
+                    size="small"
+                    color="inherit"
+                    variant="contained"
+                    onClick={() => contact?.id && handleDelete(contact.id)}
+                    sx={{ ml: 1 }}
+                  >
+                    {t("actions.delete")}
+                  </Button>
+                </TableCell>
+              </>
+            )}
+            fixedHeaderContent={() => (
+              <TableRow>
+                <TableCell>{t("table.column.email")}</TableCell>
+                <TableCell>{t("table.column.firstname")}</TableCell>
+                <TableCell>{t("table.column.lastname")}</TableCell>
+                <TableCell>{t("table.column.phone")}</TableCell>
+                <TableCell>{t("table.column.job")}</TableCell>
+                <TableCell>{t("table.column.companies")}</TableCell>
+                <TableCell>{t("table.column.actions")}</TableCell>
+              </TableRow>
+            )}
+          />
+          {query.isFetching && <LinearProgress />}
+        </Grid>
+      </Grid>
+    </Container>
+  );
+}

--- a/src/services/api/services/contacts.ts
+++ b/src/services/api/services/contacts.ts
@@ -1,0 +1,92 @@
+import { useCallback } from "react";
+import useFetch from "../use-fetch";
+import { API_URL } from "../config";
+import wrapperFetchJsonResponse from "../wrapper-fetch-json-response";
+import { Contact } from "../types/contact";
+import { InfinityPaginationType } from "../types/infinity-pagination";
+import { RequestConfigType } from "./types/request-config";
+
+export type ContactsRequest = { page: number; limit: number };
+export type ContactsResponse = InfinityPaginationType<Contact>;
+
+export function useGetContactsService() {
+  const fetch = useFetch();
+  return useCallback(
+    (data: ContactsRequest, requestConfig?: RequestConfigType) => {
+      const requestUrl = new URL(`${API_URL}/v1/contacts`);
+      requestUrl.searchParams.append("page", data.page.toString());
+      requestUrl.searchParams.append("limit", data.limit.toString());
+      return fetch(requestUrl, {
+        method: "GET",
+        ...requestConfig,
+      }).then(wrapperFetchJsonResponse<ContactsResponse>);
+    },
+    [fetch]
+  );
+}
+
+export type ContactByIdRequest = { id: number | string };
+export type ContactByIdResponse = Contact;
+
+export function useGetContactByIdService() {
+  const fetch = useFetch();
+  return useCallback(
+    (data: ContactByIdRequest, requestConfig?: RequestConfigType) => {
+      return fetch(`${API_URL}/v1/contacts/${data.id}`, {
+        method: "GET",
+        ...requestConfig,
+      }).then(wrapperFetchJsonResponse<ContactByIdResponse>);
+    },
+    [fetch]
+  );
+}
+
+export type ContactPostRequest = Omit<Contact, "id">;
+export type ContactPostResponse = Contact;
+
+export function usePostContactService() {
+  const fetch = useFetch();
+  return useCallback(
+    (data: ContactPostRequest, requestConfig?: RequestConfigType) => {
+      return fetch(`${API_URL}/v1/contacts`, {
+        method: "POST",
+        body: JSON.stringify(data),
+        ...requestConfig,
+      }).then(wrapperFetchJsonResponse<ContactPostResponse>);
+    },
+    [fetch]
+  );
+}
+
+export type ContactPutRequest = { id: number | string; data: ContactPostRequest };
+export type ContactPutResponse = Contact;
+
+export function usePutContactService() {
+  const fetch = useFetch();
+  return useCallback(
+    (data: ContactPutRequest, requestConfig?: RequestConfigType) => {
+      return fetch(`${API_URL}/v1/contacts/${data.id}`, {
+        method: "PUT",
+        body: JSON.stringify(data.data),
+        ...requestConfig,
+      }).then(wrapperFetchJsonResponse<ContactPutResponse>);
+    },
+    [fetch]
+  );
+}
+
+export type ContactDeleteRequest = { id: number | string };
+export type ContactDeleteResponse = undefined;
+
+export function useDeleteContactService() {
+  const fetch = useFetch();
+  return useCallback(
+    (data: ContactDeleteRequest, requestConfig?: RequestConfigType) => {
+      return fetch(`${API_URL}/v1/contacts/${data.id}`, {
+        method: "DELETE",
+        ...requestConfig,
+      }).then(wrapperFetchJsonResponse<ContactDeleteResponse>);
+    },
+    [fetch]
+  );
+}

--- a/src/services/api/types/contact.ts
+++ b/src/services/api/types/contact.ts
@@ -1,0 +1,12 @@
+export interface Contact {
+  id?: number;
+  email: string;
+  phone: string;
+  firstname: string;
+  lastname: string;
+  birthdate?: string;
+  job: string;
+  companies: { id: number; name: string }[];
+}
+
+export type ContactFormData = Omit<Contact, "id">;

--- a/src/services/i18n/locales/en/contacts.json
+++ b/src/services/i18n/locales/en/contacts.json
@@ -1,0 +1,50 @@
+{
+  "title": {
+    "list": "Contacts",
+    "create": "Create Contact",
+    "edit": "Edit Contact"
+  },
+  "table": {
+    "column": {
+      "email": "Email",
+      "firstname": "First Name",
+      "lastname": "Last Name",
+      "phone": "Phone",
+      "job": "Job",
+      "companies": "Companies",
+      "actions": "Actions"
+    }
+  },
+  "form": {
+    "email": { "label": "Email" },
+    "firstname": { "label": "First Name" },
+    "lastname": { "label": "Last Name" },
+    "phone": { "label": "Phone" },
+    "birthdate": { "label": "Birthdate" },
+    "job": { "label": "Job" },
+    "companies": { "label": "Companies" }
+  },
+  "buttons": {
+    "submit": "Submit",
+    "cancel": "Cancel"
+  },
+  "alerts": {
+    "created": "Contact created successfully",
+    "updated": "Contact updated successfully",
+    "deleted": "Contact deleted successfully"
+  },
+  "validation": {
+    "required": "This field is required",
+    "minCompanies": "At least one company required"
+  },
+  "actions": {
+    "edit": "Edit",
+    "delete": "Delete"
+  },
+  "confirm": {
+    "delete": {
+      "title": "Delete Contact",
+      "message": "Are you sure you want to delete this contact?"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- create Contact type and API services
- add ContactForm and ContactList components
- implement contacts pages (list, create, edit)
- add React Query hooks for contacts
- provide English translations for contacts

## Testing
- `npm run lint` *(fails: sh: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68402f3f16dc832287aac68f4d7a8fd3